### PR TITLE
Optimistically report changes to esphome

### DIFF
--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -305,19 +305,20 @@ void MitsubishiHeatPump::hpSettingsChanged() {
     /*
      * Compute running state from mode & temperatures
      */
-    this->action = climate::CLIMATE_ACTION_OFF;
     switch (this->mode) {
-      case climate::CLIMATE_MODE_HEAT:
-        if (this->current_temperature < this->target_temperature) {
-          this->action = climate::CLIMATE_ACTION_HEATING;
-        }
-        break;
-      case climate::CLIMATE_MODE_COOL:
-      case climate::CLIMATE_MODE_DRY:
-        if (this->current_temperature > this->target_temperature) {
-          this->action = climate::CLIMATE_ACTION_COOLING;
-        }
-        break;
+        case climate::CLIMATE_MODE_HEAT:
+            if (this->current_temperature < this->target_temperature) {
+                this->action = climate::CLIMATE_ACTION_HEATING;
+            }
+            break;
+        case climate::CLIMATE_MODE_COOL:
+        case climate::CLIMATE_MODE_DRY:
+            if (this->current_temperature > this->target_temperature) {
+                this->action = climate::CLIMATE_ACTION_COOLING;
+            }
+            break;
+      default:
+          this->action = climate::CLIMATE_ACTION_OFF;
     }
 
     /*

--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -317,8 +317,8 @@ void MitsubishiHeatPump::hpSettingsChanged() {
                 this->action = climate::CLIMATE_ACTION_COOLING;
             }
             break;
-      default:
-          this->action = climate::CLIMATE_ACTION_OFF;
+        default:
+            this->action = climate::CLIMATE_ACTION_OFF;
     }
 
     /*

--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -206,6 +206,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         }
     }
     ESP_LOGD(TAG, "control - Was HeatPump updated? %s", YESNO(updated));
+
     // send the update back to esphome:
     this->publish_state();
     // and the heat pump:
@@ -305,14 +306,18 @@ void MitsubishiHeatPump::hpSettingsChanged() {
      * Compute running state from mode & temperatures
      */
     this->action = climate::CLIMATE_ACTION_OFF;
-    if (this->mode == climate::CLIMATE_MODE_HEAT) {
-      if (this->current_temperature < this->target_temperature) {
-	this->action = climate::CLIMATE_ACTION_HEATING;
-      }
-    } else if(this->mode == climate::CLIMATE_MODE_COOL) {
-      if (this->current_temperature > this->target_temperature) {
-	this->action = climate::CLIMATE_ACTION_COOLING;
-      }
+    switch (this->mode) {
+      case climate::CLIMATE_MODE_HEAT:
+        if (this->current_temperature < this->target_temperature) {
+          this->action = climate::CLIMATE_ACTION_HEATING;
+        }
+        break;
+      case climate::CLIMATE_MODE_COOL:
+      case climate::CLIMATE_MODE_DRY:
+        if (this->current_temperature > this->target_temperature) {
+          this->action = climate::CLIMATE_ACTION_COOLING;
+        }
+        break;
     }
 
     /*


### PR DESCRIPTION
this makes two changes:

- when receiving a new setpoint or mode from esphome, immediately report it back as the current status without waiting for it to round-trip through the heat pump. This means that temperatures set in F will wait 30 seconds before being converted to C, which feels weird but is, at least, very easy.

- When in HEAT, COOL or DRY, report the current hvac 'action' very simplistically: if the current tempertaure is above/below the set point, then you're doing the current action. This doesn't reflect what the heat pump is actually doing, but it is prettier.