### PR TITLE
Add "idle" states during heating and cooling.

### DIFF
--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -310,13 +310,20 @@ void MitsubishiHeatPump::hpSettingsChanged() {
             if (this->current_temperature < this->target_temperature) {
                 this->action = climate::CLIMATE_ACTION_HEATING;
             }
+            else {
+                this->action = climate::CLIMATE_ACTION_IDLE;
+            }
             break;
         case climate::CLIMATE_MODE_COOL:
-        case climate::CLIMATE_MODE_DRY:
             if (this->current_temperature > this->target_temperature) {
                 this->action = climate::CLIMATE_ACTION_COOLING;
             }
+            else {
+                this->action = climate::CLIMATE_ACTION_IDLE;
+            }
             break;
+        case climate::CLIMATE_MODE_DRY:
+            this->action = climate::CLIMATE_ACTION_DRYING;
         default:
             this->action = climate::CLIMATE_ACTION_OFF;
     }


### PR DESCRIPTION
Dev version of esphome supports an idle state, so we'll take a guess at
what the state is at a given point by comparing the set point.

Note that this commit does not take into account hysteresis around the
set point, and just assumes that if the temperature is at or over the
set point during heating that the unit is idle, or if the temperature is
at or under the setpoint during cooling that it's idle.