### PR TITLE
Get running state from heatpump

### DIFF
--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -128,6 +128,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
             case climate::CLIMATE_MODE_FAN_ONLY:
                 hp->setModeSetting("FAN");
                 hp->setPowerSetting("ON");
+                this->action = climate::CLIMATE_ACTION_FAN;
                 updated = true;
                 break;
             case climate::CLIMATE_MODE_OFF:
@@ -247,6 +248,7 @@ void MitsubishiHeatPump::hpSettingsChanged() {
             this->mode = climate::CLIMATE_MODE_FAN_ONLY;
         } else if (strcmp(currentSettings.mode, "AUTO") == 0) {
             this->mode = climate::CLIMATE_MODE_AUTO;
+            this->action = climate::CLIMATE_ACTION_FAN;
         } else {
             ESP_LOGW(
                     TAG,

--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -138,6 +138,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
             case climate::CLIMATE_MODE_OFF:
             default:
                 hp->setPowerSetting("OFF");
+                this->action = climate::CLIMATE_ACTION_OFF;
                 updated = true;
                 break;
         }
@@ -266,6 +267,7 @@ void MitsubishiHeatPump::hpSettingsChanged() {
         }
     } else {
         this->mode = climate::CLIMATE_MODE_OFF;
+        this->action = climate::CLIMATE_ACTION_OFF;
     }
 
     ESP_LOGI(TAG, "Climate mode is: %i", this->mode);

--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -246,9 +246,9 @@ void MitsubishiHeatPump::hpSettingsChanged() {
             this->mode = climate::CLIMATE_MODE_COOL;
         } else if (strcmp(currentSettings.mode, "FAN") == 0) {
             this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+            this->action = climate::CLIMATE_ACTION_FAN;
         } else if (strcmp(currentSettings.mode, "AUTO") == 0) {
             this->mode = climate::CLIMATE_MODE_AUTO;
-            this->action = climate::CLIMATE_ACTION_FAN;
         } else {
             ESP_LOGW(
                     TAG,

--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -118,6 +118,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
             case climate::CLIMATE_MODE_DRY:
                 hp->setModeSetting("DRY");
                 hp->setPowerSetting("ON");
+                this->action = climate::CLIMATE_ACTION_DRYING;
                 updated = true;
                 break;
             case climate::CLIMATE_MODE_AUTO:
@@ -242,6 +243,7 @@ void MitsubishiHeatPump::hpSettingsChanged() {
             this->mode = climate::CLIMATE_MODE_HEAT;
         } else if (strcmp(currentSettings.mode, "DRY") == 0) {
             this->mode = climate::CLIMATE_MODE_DRY;
+            this->action = climate::CLIMATE_ACTION_DRYING;
         } else if (strcmp(currentSettings.mode, "COOL") == 0) {
             this->mode = climate::CLIMATE_MODE_COOL;
         } else if (strcmp(currentSettings.mode, "FAN") == 0) {
@@ -334,13 +336,15 @@ void MitsubishiHeatPump::hpStatusChanged(heatpumpStatus currentStatus) {
             break;
         case climate::CLIMATE_MODE_DRY:
             if (currentStatus.operating) {
-	      this->action = climate::CLIMATE_ACTION_DRYING;
+                this->action = climate::CLIMATE_ACTION_DRYING;
             }
             else {
                 this->action = climate::CLIMATE_ACTION_IDLE;
             }
+            break;
         case climate::CLIMATE_MODE_FAN_ONLY:
             this->action = climate::CLIMATE_ACTION_FAN;
+            break;
         default:
             this->action = climate::CLIMATE_ACTION_OFF;
     }


### PR DESCRIPTION
Turns out the library exposes the compressor running status, let's use that instead of comparisons. Also adds the FAN action and fixes a bug where the current action was only computed on mode changes, not on updates from the heat pump.