### PR TITLE
Don't treat swing mode 'auto' as CLIMATE_SWING_VERTICAL

### DIFF
--- a/espmhp.cpp
+++ b/espmhp.cpp
@@ -283,10 +283,7 @@ void MitsubishiHeatPump::hpSettingsChanged() {
     /* ******** HANDLE MITSUBISHI VANE CHANGES ********
      * const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
      */
-    if (
-            (strcmp(currentSettings.vane, "AUTO") == 0)
-            || (strcmp(currentSettings.vane, "SWING") == 0)
-    ) {
+    if (strcmp(currentSettings.vane, "SWING") == 0) {
         this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
     }
     else {


### PR DESCRIPTION
When the swing mode is set to 'off' from 'vertical', after a while the heatpump updates `currentSettings.vane` to 'auto'.  As a result, the swing mode gets erroneously sets back to vertical.

Swing mode 'auto' is not the same as 'swing' according to the following excerpt from a mitsubishi manual:

![swing](https://user-images.githubusercontent.com/20846761/86311393-e398bf00-bc52-11ea-907f-8579116e30db.PNG)

Auto seems to be just a shorthand to set the vane at position 1 when it's in the cool/dry mode and position 5 when it's in heat mode. As such, swing mode `auto` should not be treated as a state of `CLIMATE_SWING_VERTICAL`.

Fixes #13