### PR TITLE
Fix HA connection thrashing when no comms

### DIFF
--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -428,6 +428,10 @@ void MitsubishiHeatPump::setup() {
 
     ESP_LOGCONFIG(TAG, "Intializing new HeatPump object.");
     this->hp = new HeatPump();
+    this->current_temperature = NAN;
+    this->target_temperature = NAN;
+    this->fan_mode = climate::CLIMATE_FAN_OFF;
+    this->swing_mode = climate::CLIMATE_SWING_OFF;
 
 #ifdef USE_CALLBACKS
     hp->setSettingsChangedCallback(


### PR DESCRIPTION
As discussed in issue #23, if the CN105 connection to the heat pump is down (i.e. unplugged, wrongly configured, etc), then the ESP device goes into a hard thrash loop where it is disconnecting and reconnecting to the HA server 2 times every second, i.e. it smashes the HA server ad-infinitum. This commit fixes this by ensuring the heat pump attributes are initialised to at least something non-random. We set the temperatures to NAN so it is clear they have not been initialised by heat pump, and thus apparent in logs etc.