### PR TITLE
Add `temperature_offset` configuration, to support calibrating the temperature sensor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ climate:
     # logging:baud_rate above to allow the built-in UART0 to function for
     # logging.
     hardware_uart: UART0
+
+    # Add a offset to all temperatures, useful if the value you get from your heatpump isn't accurate.
+    temperature_offset: -2C
 ```
 
 # Advanced configuration

--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -16,6 +16,7 @@ from esphome.core import CORE, coroutine
 AUTO_LOAD = ["climate"]
 
 CONF_SUPPORTS = "supports"
+CONF_TEMPERATURE_OFFSET = "temperature_offset"
 DEFAULT_CLIMATE_MODES = ["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "DIFFUSE", "LOW", "MEDIUM", "MIDDLE", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL"]
@@ -57,6 +58,7 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
                     cv.ensure_list(climate.validate_climate_swing_mode),
             }
         ),
+        cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -68,6 +70,9 @@ def to_code(config):
 
     if CONF_BAUD_RATE in config:
         cg.add(var.set_baud_rate(config[CONF_BAUD_RATE]))
+
+    if CONF_TEMPERATURE_OFFSET in config:
+        cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
 
     supports = config[CONF_SUPPORTS]
     traits = var.config_traits()

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -68,6 +68,10 @@ void MitsubishiHeatPump::set_baud_rate(int baud) {
     this->baud_ = baud;
 }
 
+void MitsubishiHeatPump::set_temperature_offset(float temperature_offset) {
+    this->temperature_offset_ = temperature_offset;
+}
+
 /**
  * Get our supported traits.
  *
@@ -359,7 +363,12 @@ void MitsubishiHeatPump::hpSettingsChanged() {
  * Report changes in the current temperature sensed by the HeatPump.
  */
 void MitsubishiHeatPump::hpStatusChanged(heatpumpStatus currentStatus) {
-    this->current_temperature = currentStatus.roomTemperature;
+    if (this->temperature_offset_.has_value()) {
+        ESP_LOGD(TAG, "Adding offset: %.1f to temperature reported from heatpump: %.1f", this->temperature_offset_.value(), currentStatus.roomTemperature);
+        this->current_temperature = currentStatus.roomTemperature + this->temperature_offset_.value();
+    } else {
+        this->current_temperature = currentStatus.roomTemperature;
+    }
     switch (this->mode) {
         case climate::CLIMATE_MODE_HEAT:
             if (currentStatus.operating) {

--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -66,6 +66,9 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         // Set the baud rate. Must be called before setup() to have any effect.
         void set_baud_rate(int);
 
+        // Set the temperature offset
+        void set_temperature_offset(float);
+
         // print the current configuration
         void dump_config() override;
 
@@ -133,6 +136,7 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         // Retrieve the HardwareSerial pointer from friend and subclasses.
         HardwareSerial *hw_serial_;
         int baud_ = 0;
+        optional<float> temperature_offset_;
 };
 
 #endif


### PR DESCRIPTION
This adds a new configuration option `temperature_offset`, if this is specified this will be added to the temperature reported from the heatpump, making it possible to correct any incorrect values reported from the heatpump.

Fixes #79