### PR TITLE
Cast pointers to void* before comparision

### DIFF
--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -451,7 +451,7 @@ void MitsubishiHeatPump::setup() {
             "hw_serial(%p) is &Serial(%p)? %s",
             this->get_hw_serial_(),
             &Serial,
-            YESNO(this->get_hw_serial_() == &Serial)
+            YESNO((void *)this->get_hw_serial_() == (void *)&Serial)
     );
 
     ESP_LOGCONFIG(TAG, "Calling hp->connect(%p)", this->get_hw_serial_());


### PR DESCRIPTION
Correct the UART comparison log message by casting pointers to void *

Fixes GH73