### PR TITLE
Feature: Configurable UART pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ climate:
     name: "My heat pump"
     hardware_uart: UART2
     baud_rate: 9600
+    rx_pin: 9
+    tx_pin: 10
     supports:
       mode: [HEAT_COOL, COOL, HEAT, FAN_ONLY]
       fan_mode: [AUTO, LOW, MEDIUM, HIGH]
@@ -350,6 +352,10 @@ climate:
 * *baud\_rate* (_Optional_): Serial BAUD rate used to communicate with the
   HeatPump. Most systems use the default value of `4800` baud, but some use
   `9600`. Default: `4800`
+* *rx\_pin* (_Optional_): pin number to use as RX for the specified hardware
+  UART (ESP32 only - ESP8266 hardware UART's pins aren't configurable).
+* *tx\_pin* (_Optional_): pin number to use as TX for the specified hardware
+  UART (ESP32 only - ESP8266 hardware UART's pins aren't configurable).
 * *update\_interval* (_Optional_, range: 0ms to 9000ms): How often this
   component polls the heatpump hardware, in milliseconds. Maximum usable value
   is 9 seconds due to underlying issues with the HeatPump library. Default: 500ms

--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -6,6 +6,8 @@ from esphome.const import (
     CONF_ID,
     CONF_HARDWARE_UART,
     CONF_BAUD_RATE,
+    CONF_RX_PIN,
+    CONF_TX_PIN,
     CONF_UPDATE_INTERVAL,
     CONF_MODE,
     CONF_FAN_MODE,
@@ -41,6 +43,8 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.GenerateID(): cv.declare_id(MitsubishiHeatPump),
         cv.Optional(CONF_HARDWARE_UART, default="UART0"): valid_uart,
         cv.Optional(CONF_BAUD_RATE): cv.positive_int,
+        cv.Optional(CONF_RX_PIN): cv.positive_int,
+        cv.Optional(CONF_TX_PIN): cv.positive_int,
         # If polling interval is greater than 9 seconds, the HeatPump library
         # reconnects, but doesn't then follow up with our data request.
         cv.Optional(CONF_UPDATE_INTERVAL, default="500ms"): cv.All(
@@ -68,6 +72,12 @@ def to_code(config):
 
     if CONF_BAUD_RATE in config:
         cg.add(var.set_baud_rate(config[CONF_BAUD_RATE]))
+
+    if CONF_RX_PIN in config:
+        cg.add(var.set_rx_pin(config[CONF_RX_PIN]))
+
+    if CONF_TX_PIN in config:
+        cg.add(var.set_tx_pin(config[CONF_TX_PIN]))
 
     supports = config[CONF_SUPPORTS]
     traits = var.config_traits()

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -68,6 +68,14 @@ void MitsubishiHeatPump::set_baud_rate(int baud) {
     this->baud_ = baud;
 }
 
+void MitsubishiHeatPump::set_rx_pin(int rx_pin) {
+    this->rx_pin_ = rx_pin;
+}
+
+void MitsubishiHeatPump::set_tx_pin(int tx_pin) {
+    this->tx_pin_ = tx_pin;
+}
+
 /**
  * Get our supported traits.
  *
@@ -455,8 +463,7 @@ void MitsubishiHeatPump::setup() {
     );
 
     ESP_LOGCONFIG(TAG, "Calling hp->connect(%p)", this->get_hw_serial_());
-
-    if (hp->connect(this->get_hw_serial_(), this->baud_, -1, -1)) {
+    if (hp->connect(this->get_hw_serial_(), this->baud_, this->rx_pin_, this->tx_pin_)) {
         hp->sync();
     }
     else {

--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -66,6 +66,12 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         // Set the baud rate. Must be called before setup() to have any effect.
         void set_baud_rate(int);
 
+        // Set the RX pin. Must be called before setup() to have any effect.
+        void set_rx_pin(int);
+
+        // Set the TX pin. Must be called before setup() to have any effect.
+        void set_tx_pin(int);
+
         // print the current configuration
         void dump_config() override;
 
@@ -133,6 +139,8 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         // Retrieve the HardwareSerial pointer from friend and subclasses.
         HardwareSerial *hw_serial_;
         int baud_ = 0;
+        int rx_pin_ = -1;
+        int tx_pin_ = -1;
 };
 
 #endif


### PR DESCRIPTION
Adds optional configuration for the UART RX and TX pins on platforms which support assigning arbitrary pins to hardware UART(s), i.e. ESP32.