### PR TITLE
Add safeguards for the set_remote_temperature function

### DIFF
--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -20,6 +20,11 @@ DEFAULT_CLIMATE_MODES = ["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "DIFFUSE", "LOW", "MEDIUM", "MIDDLE", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL"]
 
+# Remote temperature timeout configuration
+CONF_REMOTE_OPERATING_TIMEOUT = "remote_temperature_operating_timeout_minutes"
+CONF_REMOTE_IDLE_TIMEOUT = "remote_temperature_idle_timeout_minutes"
+CONF_REMOTE_PING_TIMEOUT = "remote_temperature_ping_timeout_minutes"
+
 MitsubishiHeatPump = cg.global_ns.class_(
     "MitsubishiHeatPump", climate.Climate, cg.PollingComponent
 )
@@ -41,6 +46,10 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.GenerateID(): cv.declare_id(MitsubishiHeatPump),
         cv.Optional(CONF_HARDWARE_UART, default="UART0"): valid_uart,
         cv.Optional(CONF_BAUD_RATE): cv.positive_int,
+        cv.Optional(CONF_REMOTE_OPERATING_TIMEOUT): cv.positive_int,
+        cv.Optional(CONF_REMOTE_IDLE_TIMEOUT): cv.positive_int,
+        cv.Optional(CONF_REMOTE_PING_TIMEOUT): cv.positive_int,
+        
         # If polling interval is greater than 9 seconds, the HeatPump library
         # reconnects, but doesn't then follow up with our data request.
         cv.Optional(CONF_UPDATE_INTERVAL, default="500ms"): cv.All(
@@ -68,6 +77,16 @@ def to_code(config):
 
     if CONF_BAUD_RATE in config:
         cg.add(var.set_baud_rate(config[CONF_BAUD_RATE]))
+
+    if CONF_REMOTE_OPERATING_TIMEOUT in config:
+        cg.add(var.set_remote_operating_timeout_minutes(config[CONF_REMOTE_OPERATING_TIMEOUT]))
+
+    if CONF_REMOTE_IDLE_TIMEOUT in config:
+        cg.add(var.set_remote_idle_timeout_minutes(config[CONF_REMOTE_IDLE_TIMEOUT]))
+
+    if CONF_REMOTE_PING_TIMEOUT in config:
+        cg.add(var.set_remote_ping_timeout_minutes(config[CONF_REMOTE_PING_TIMEOUT]))
+
 
     supports = config[CONF_SUPPORTS]
     traits = var.config_traits()

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -9,7 +9,8 @@
  * Author: @am-io on Github.
  * Author: @nao-pon on Github.
  * Author: Simon Knopp @sijk on Github
- * Last Updated: 2021-05-27
+ * Author: Paul Murphy @donutsoft on GitHub
+ * Last Updated: 2023-04-22
  * License: BSD
  *
  * Requirements:
@@ -40,6 +41,10 @@ MitsubishiHeatPump::MitsubishiHeatPump(
     this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
+
+    // Assume a succesful connection was made to the ESPHome controller on
+    // launch.
+    this->ping();
 }
 
 void MitsubishiHeatPump::check_logger_conflict_() {
@@ -62,6 +67,7 @@ void MitsubishiHeatPump::update() {
     heatpumpStatus currentStatus = hp->getStatus();
     this->hpStatusChanged(currentStatus);
 #endif
+    this->enforce_remote_temperature_sensor_timeout();
 }
 
 void MitsubishiHeatPump::set_baud_rate(int baud) {
@@ -402,12 +408,68 @@ void MitsubishiHeatPump::hpStatusChanged(heatpumpStatus currentStatus) {
             this->action = climate::CLIMATE_ACTION_OFF;
     }
 
+    this->operating_ = currentStatus.operating;
+
     this->publish_state();
 }
 
 void MitsubishiHeatPump::set_remote_temperature(float temp) {
     ESP_LOGD(TAG, "Setting remote temp: %.1f", temp);
+    if (temp > 0) {
+        last_remote_temperature_update_ = std::chrono::steady_clock::now();
+    } else {
+        last_remote_temperature_update_.reset();
+    }
+
     this->hp->setRemoteTemperature(temp);
+}
+
+void MitsubishiHeatPump::ping() {
+    ESP_LOGD(TAG, "Ping request received");
+    last_ping_request_ = std::chrono::steady_clock::now();
+}
+
+void MitsubishiHeatPump::set_remote_operating_timeout_minutes(int minutes) {
+    ESP_LOGD(TAG, "Setting remote operating timeout time: %d minutes", minutes);
+    remote_operating_timeout_ = std::chrono::minutes(minutes);
+}
+
+void MitsubishiHeatPump::set_remote_idle_timeout_minutes(int minutes) {
+    ESP_LOGD(TAG, "Setting remote idle timeout time: %d minutes", minutes);
+    remote_idle_timeout_ = std::chrono::minutes(minutes);
+}
+
+void MitsubishiHeatPump::set_remote_ping_timeout_minutes(int minutes) {
+    ESP_LOGD(TAG, "Setting remote ping timeout time: %d minutes", minutes);
+    remote_ping_timeout_ = std::chrono::minutes(minutes);
+}
+
+void MitsubishiHeatPump::enforce_remote_temperature_sensor_timeout() {
+    // Handle ping timeouts.    
+    if (remote_ping_timeout_.has_value() && last_ping_request_.has_value()) {
+        auto time_since_last_ping = 
+            std::chrono::steady_clock::now() - last_ping_request_.value();
+        if(time_since_last_ping > remote_ping_timeout_.value()) {
+            ESP_LOGW(TAG, "Ping timeout.");
+            this->set_remote_temperature(0);
+            last_ping_request_.reset();
+            return;
+        }
+    }
+
+    // Handle set_remote_temperature timeouts.
+    auto remote_set_temperature_timeout = 
+        this->operating_ ? remote_operating_timeout_ : remote_idle_timeout_;
+    if (remote_set_temperature_timeout.has_value() && 
+            last_remote_temperature_update_.has_value()) {
+        auto time_since_last_temperature_update = 
+            std::chrono::steady_clock::now() - last_remote_temperature_update_.value();
+        if (time_since_last_temperature_update > remote_set_temperature_timeout.value()) {
+            ESP_LOGW(TAG, "Set remote temperature timeout, operating=%d", this->operating_);
+            this->set_remote_temperature(0);
+            return;            
+        }
+    }
 }
 
 void MitsubishiHeatPump::setup() {

--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -19,6 +19,7 @@
 
 #include "esphome.h"
 #include "esphome/core/preferences.h"
+#include <chrono>
 
 #include "HeatPump.h"
 using namespace esphome;
@@ -97,6 +98,22 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         // set_remote_temp(0) to switch back to the internal sensor.
         void set_remote_temperature(float);
 
+        // Used to validate that a connection is present between the controller
+        // and this heatpump.
+        void ping();
+
+        // Number of minutes before the heatpump reverts back to the internal
+        // temperature sensor if the machine is currently operating.
+        void set_remote_operating_timeout_minutes(int);
+
+        // Number of minutes before the heatpump reverts back to the internal
+        // temperature sensor if the machine is currently idle.
+        void set_remote_idle_timeout_minutes(int);
+
+        // Number of minutes before the heatpump reverts back to the internal
+        // temperature sensor if a ping isn't received from the controller.
+        void set_remote_ping_timeout_minutes(int);
+
     protected:
         // HeatPump object using the underlying Arduino library.
         HeatPump* hp;
@@ -130,9 +147,19 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         static optional<float> load(ESPPreferenceObject& storage);
 
     private:
+        void enforce_remote_temperature_sensor_timeout();
+
         // Retrieve the HardwareSerial pointer from friend and subclasses.
         HardwareSerial *hw_serial_;
         int baud_ = 0;
+        bool operating_ = false;
+        
+        optional<std::chrono::duration<long long, std::ratio<60>>> remote_operating_timeout_;
+        optional<std::chrono::duration<long long, std::ratio<60>>> remote_idle_timeout_;
+        optional<std::chrono::duration<long long, std::ratio<60>>> remote_ping_timeout_;
+
+        optional<std::chrono::time_point<std::chrono::steady_clock>> last_remote_temperature_update_;
+        optional<std::chrono::time_point<std::chrono::steady_clock>> last_ping_request_;
 };
 
 #endif


### PR DESCRIPTION
I've added some safety guards for the set_remote_temperature function which will ensure that the Mitsubishi will revert back to internal temperature in the event that the remote sensor goes down or cannot be communicated with.

I've separated this out into 3 different timeouts
1. While the machine is heating or cooling. Timeouts should be shorter while the machine is in this state as we expect the temperature to shift when heat is being pumped, and also the cost of failure is higher in this case.
2. While the machine is idle. Timeout can be longer as some zigbee based temperature sensors will only send updates once a temperature change happens, and if they do happen to go offline then the cost is minimal to the user (unlike the heating/cooling case)
3. Ping timeouts: If HomeAssistant/NodeRed/WiFi goes down. This should be a rapid timeout as there is no chance that the heatpump can receive remote sensor updates if this happens.


This is my first time doing any ESPHome development, so any feedback on how to do this better would be appreciated. And thank you for all your hard work in running this project!