### PR TITLE
Add vertical and horizontal vane position controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 
 # Python cache
 __pycache__
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -4,23 +4,28 @@ Wirelessly control your Mitsubishi Comfort HVAC equipment with an ESP8266 or
 ESP32 using the [ESPHome](https://esphome.io) framework.
 
 ## Features
-* Instant feedback of command changes via RF Remote to HomeAssistant or MQTT.
-* Direct control without the remote.
-* Uses the [SwiCago/HeatPump](https://github.com/SwiCago/HeatPump) Arduino
+
+- Instant feedback of command changes via RF Remote to HomeAssistant or MQTT.
+- Direct control without the remote.
+- Uses the [SwiCago/HeatPump](https://github.com/SwiCago/HeatPump) Arduino
   libary to talk to the unit directly via the internal `CN105` connector.
 
 ## Requirements
-* https://github.com/SwiCago/HeatPump
-* ESPHome 1.19.1 or greater
+
+- https://github.com/SwiCago/HeatPump
+- ESPHome 1.19.1 or greater
 
 ## Supported Microcontrollers
+
 This library should work on most ESP8266 or ESP32 platforms. It has been tested
 with the following MCUs:
-* Generic ESP-01S board (ESP8266)
-* WeMos D1 Mini (ESP8266)
-* Generic ESP32 Dev Kit (ESP32)
+
+- Generic ESP-01S board (ESP8266)
+- WeMos D1 Mini (ESP8266)
+- Generic ESP32 Dev Kit (ESP32)
 
 ## Supported Mitsubishi Climate Units
+
 The underlying HeatPump library works with a number of Mitsubishi HVAC
 units. Basically, if the unit has a `CN105` header on the main board, it should
 work with this library. The [HeatPump
@@ -34,14 +39,17 @@ available.
 
 The whole integration with this libary and the underlying HeatPump has been
 tested by the author on the following units:
-* `MSZ-GL06NA`
-* `MFZ-KA09NA`
+
+- `MSZ-GL06NA`
+- `MFZ-KA09NA`
+- `MSZ-FH35V`
 
 ## Usage
+
 ### Step 1: Build a control circuit.
 
 Build a control circuit with your MCU as detailed in the [SwiCago/HeatPump
- README](https://github.com/SwiCago/HeatPump/blob/master/README.md#demo-circuit).
+README](https://github.com/SwiCago/HeatPump/blob/master/README.md#demo-circuit).
 You can use either an ESP8266 or an ESP32 for this.
 
 Note: several users have reported that they've been able to get away with
@@ -70,6 +78,7 @@ external_components:
 Version 2.0 and greater of this libary use the ESPHome `external_components`
 feature, which is a huge step forward in terms of usability. In order to make
 things compile correctly, you will need to:
+
 1. Remove the `libraries` section that imports
    `https://github.com/SwiCago/HeatPump`, as this is handled by the
    `external_component` section of manifest.
@@ -81,15 +90,16 @@ things compile correctly, you will need to:
 5. You may also have to delete the _esphomenodename_ directory that
    corresponds with your _esphomenodename.yaml_ configuration file
    completely. This directory may exist in your base config directory,
-   or in `config/.esphome/build`.  Testing with ESPHome 0.18.x showed this 
+   or in `config/.esphome/build`. Testing with ESPHome 0.18.x showed this
    to be necessary to get the cached copy of src/esphome-mitsubishiheatpump to
    go away entirely, as the "Clean Build Files" isn't as thorough as one would like.
 
-*Note:* Failure to delete the old source directory and remove the `includes`
+_Note:_ Failure to delete the old source directory and remove the `includes`
 and `libraries` lines will likely result in compilation errors complaining
 about duplicate declarations of `MitsubishiHeatPump::traits()`.
 
 ##### Example error
+
 ```
 Linking /data/bedroom_east_heatpump/.pioenvs/bedroom_east_heatpump/firmware.elf
 /root/.platformio/packages/toolchain-xtensa/bin/../lib/gcc/xtensa-lx106-elf/4.8.2/../../../../xtensa-lx106-elf/bin/ld: /data/bedroom_east_heatpump/.pioenvs/bedroom_east_heatpump/src/esphome/components/mitsubishi_heatpump/espmhp.cpp.o: in function `MitsubishiHeatPump::traits()':
@@ -123,10 +133,10 @@ logger:
 On ESP32 you can change `hardware_uart` to `UART1` or `UART2` and keep logging
 enabled on the main serial port.
 
-*Note:* this component DOES NOT use the ESPHome `uart` component, as it
+_Note:_ this component DOES NOT use the ESPHome `uart` component, as it
 requires direct access to a hardware UART via the Arduino `HardwareSerial`
 class. The Mitsubishi Heatpump units use an atypical serial port setting ("even
-parity").  Parity bit support is not implemented in any of the existing
+parity"). Parity bit support is not implemented in any of the existing
 software serial libraries, including the one in ESPHome. There's currently no
 way to guarantee access to a hardware UART nor retrieve the `HardwareSerial`
 handle from the `uart` component within the ESPHome framework.
@@ -142,7 +152,6 @@ various items prefixed with `!secret`.
 substitutions:
   name: hptest
   friendly_name: Test Heatpump
-
 
 esphome:
   name: ${name}
@@ -162,10 +171,10 @@ wifi:
 # Note: if upgrading from 1.x releases of esphome-mitsubishiheatpump, be sure
 # to remove any old entries from the `libraries` and `includes` section.
 #libraries:
-  # Remove reference to SwiCago/HeatPump
+# Remove reference to SwiCago/HeatPump
 
 #includes:
-  # Remove reference to src/esphome-mitsubishiheatpump
+# Remove reference to src/esphome-mitsubishiheatpump
 
 captive_portal:
 
@@ -225,6 +234,10 @@ climate:
     # logging:baud_rate above to allow the built-in UART0 to function for
     # logging.
     hardware_uart: UART0
+    horizontal_vane_select:
+      name: Horizontal Vane Position
+    vertical_vane_select:
+      name: Horizontal Vane Position
 ```
 
 # Advanced configuration
@@ -242,7 +255,7 @@ climate:
     supports:
       mode: [HEAT_COOL, COOL, HEAT, FAN_ONLY]
       fan_mode: [AUTO, LOW, MEDIUM, HIGH]
-      swing_mode: [OFF, VERTICAL]
+      swing_mode: [OFF, VERTICAL, HORIZONTAL, BOTH]
     visual:
       min_temperature: 16
       max_temperature: 31
@@ -251,29 +264,30 @@ climate:
 
 ## Configuration variables that affect this library directly
 
-* *hardware\_uart* (_Optional_): the hardware UART instance to use for
+- _hardware_uart_ (_Optional_): the hardware UART instance to use for
   communcation with the heatpump. On ESP8266, only `UART0` is usable. On ESP32,
   `UART0`, `UART1`, and `UART2` are all valid choices. Default: `UART0`
-* *baud\_rate* (_Optional_): Serial BAUD rate used to communicate with the
+- _baud_rate_ (_Optional_): Serial BAUD rate used to communicate with the
   HeatPump. Most systems use the default value of `4800` baud, but some use
   `9600`. Default: `4800`
-* *update\_interval* (_Optional_, range: 0ms to 9000ms): How often this
+- _update_interval_ (_Optional_, range: 0ms to 9000ms): How often this
   component polls the heatpump hardware, in milliseconds. Maximum usable value
   is 9 seconds due to underlying issues with the HeatPump library. Default: 500ms
-* *supports* (_Optional_): Supported features for the device.  ** *mode*
-  (_Optional_, list): Supported climate modes for the HeatPump. Default:
+- _supports_ (_Optional_): Supported features for the device.  
+   ** _mode_ (_Optional_, list): Supported climate modes for the HeatPump. Default:
   `['HEAT_COOL', 'COOL', 'HEAT', 'DRY', 'FAN_ONLY']`
-  ** *fan_mode* (_Optional_, list):
-	Supported fan speeds for the HeatPump. Default: `['AUTO', 'DIFFUSE', 'LOW',
-	'MEDIUM', 'MIDDLE', 'HIGH']` ** *swing_mode* (_Optional_, list): Supported
-	fan swing modes. Most Mitsubishi units only support the default. Default:
-    `['OFF', 'VERTICAL']`
+  ** _fan_mode_ (_Optional_, list):
+  Supported fan speeds for the HeatPump. Default: `['AUTO', 'DIFFUSE', 'LOW',
+'MEDIUM', 'MIDDLE', 'HIGH']` \*\* _swing_mode_ (_Optional_, list): Supported
+  fan swing modes. Most Mitsubishi units only support the default. Default:
+  `['OFF', 'VERTICAL', 'HORIZONTAL', 'BOTH']`
+-
 
 ## Other configuration
 
-* *id* (_Optional_): used to identify multiple instances, e.g. "denheatpump"
-* *name* (_Required_): The name of the climate component, e.g. "Den Heatpump"
-* *visual* (_Optional_): The core `Climate` component has several *visual*
+- _id_ (_Optional_): used to identify multiple instances, e.g. "denheatpump"
+- _name_ (_Required_): The name of the climate component, e.g. "Den Heatpump"
+- _visual_ (_Optional_): The core `Climate` component has several _visual_
   options that can be set. See the [Climate
   Component](https://esphome.io/components/climate/index.html) documentation for
   details.
@@ -303,7 +317,7 @@ sensor:
       name: "Lounge temperature"
       on_value:
         then:
-          - lambda: 'id(hp).set_remote_temperature(x);'
+          - lambda: "id(hp).set_remote_temperature(x);"
 
   # Or you could use a HomeAssistant sensor
   - platform: homeassistant
@@ -311,7 +325,7 @@ sensor:
     entity_id: sensor.temperature_sensor
     on_value:
       then:
-        - lambda: 'id(hp).set_remote_temperature(x);'
+        - lambda: "id(hp).set_remote_temperature(x);"
 ```
 
 Alternatively you could define a
@@ -325,16 +339,17 @@ api:
       variables:
         temperature: float
       then:
-        - lambda: 'id(hp).set_remote_temperature(temperature);'
+        - lambda: "id(hp).set_remote_temperature(temperature);"
 
     - service: use_internal_temperature
       then:
-        - lambda: 'id(hp).set_remote_temperature(0);'
+        - lambda: "id(hp).set_remote_temperature(0);"
 ```
 
 # See Also
 
 ## Other Implementations
+
 The [gysmo38/mitsubishi2MQTT](https://github.com/gysmo38/mitsubishi2MQTT)
 Arduino sketch also uses the `SwiCago/HeatPump`
 library, and works with MQTT directly. The author of this implementation found
@@ -354,7 +369,8 @@ the settings via an IR remote.
 ## Reference documentation
 
 The author referred to the following documentation repeatedly:
-* [ESPHome Custom Sensors Reference](https://esphome.io/components/sensor/custom.html)
-* [ESPHome Custom Climate Components Reference](https://esphome.io/components/climate/custom.html)
-* [ESPHome External Components Reference](https://esphome.io/components/external_components.html)
-* [Source for ESPHome's Climate Component](https://github.com/esphome/esphome/tree/master/esphome/components/climate)
+
+- [ESPHome Custom Sensors Reference](https://esphome.io/components/sensor/custom.html)
+- [ESPHome Custom Climate Components Reference](https://esphome.io/components/climate/custom.html)
+- [ESPHome External Components Reference](https://esphome.io/components/external_components.html)
+- [Source for ESPHome's Climate Component](https://github.com/esphome/esphome/tree/master/esphome/components/climate)

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -27,46 +27,42 @@ using namespace esphome;
  *   hw_serial: pointer to an Arduino HardwareSerial instance
  *   poll_interval: polling interval in milliseconds
  */
-MitsubishiHeatPump::MitsubishiHeatPump(
-        HardwareSerial* hw_serial,
-        uint32_t poll_interval
-) :
-    PollingComponent{poll_interval}, // member initializers list
-    hw_serial_{hw_serial}
-{
-    this->traits_.set_supports_action(true);
-    this->traits_.set_supports_current_temperature(true);
-    this->traits_.set_supports_two_point_target_temperature(false);
-    this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
-    this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
-    this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
+MitsubishiHeatPump::MitsubishiHeatPump(HardwareSerial *hw_serial,
+                                       uint32_t poll_interval)
+    : PollingComponent{poll_interval},  // member initializers list
+      hw_serial_{hw_serial} {
+  this->traits_.set_supports_action(true);
+  this->traits_.set_supports_current_temperature(true);
+  this->traits_.set_supports_two_point_target_temperature(false);
+  this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
+  this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
+  this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
 }
 
 void MitsubishiHeatPump::check_logger_conflict_() {
 #ifdef USE_LOGGER
-    if (this->get_hw_serial_() == logger::global_logger->get_hw_serial()) {
-        ESP_LOGW(TAG, "  You're using the same serial port for logging"
-                " and the MitsubishiHeatPump component. Please disable"
-                " logging over the serial port by setting"
-                " logger:baud_rate to 0.");
-    }
+  if (this->get_hw_serial_() == logger::global_logger->get_hw_serial()) {
+    ESP_LOGW(TAG,
+             "  You're using the same serial port for logging"
+             " and the MitsubishiHeatPump component. Please disable"
+             " logging over the serial port by setting"
+             " logger:baud_rate to 0.");
+  }
 #endif
 }
 
 void MitsubishiHeatPump::update() {
-    // This will be called every "update_interval" milliseconds.
-    //this->dump_config();
-    this->hp->sync();
+  // This will be called every "update_interval" milliseconds.
+  // this->dump_config();
+  this->hp->sync();
 #ifndef USE_CALLBACKS
-    this->hpSettingsChanged();
-    heatpumpStatus currentStatus = hp->getStatus();
-    this->hpStatusChanged(currentStatus);
+  this->hpSettingsChanged();
+  heatpumpStatus currentStatus = hp->getStatus();
+  this->hpStatusChanged(currentStatus);
 #endif
 }
 
-void MitsubishiHeatPump::set_baud_rate(int baud) {
-    this->baud_ = baud;
-}
+void MitsubishiHeatPump::set_baud_rate(int baud) { this->baud_ = baud; }
 
 /**
  * Get our supported traits.
@@ -78,9 +74,7 @@ void MitsubishiHeatPump::set_baud_rate(int baud) {
  * Returns:
  *   This class' supported climate::ClimateTraits.
  */
-climate::ClimateTraits MitsubishiHeatPump::traits() {
-    return traits_;
-}
+climate::ClimateTraits MitsubishiHeatPump::traits() { return traits_; }
 
 /**
  * Modify our supported traits.
@@ -88,8 +82,116 @@ climate::ClimateTraits MitsubishiHeatPump::traits() {
  * Returns:
  *   A reference to this class' supported climate::ClimateTraits.
  */
-climate::ClimateTraits& MitsubishiHeatPump::config_traits() {
-    return traits_;
+climate::ClimateTraits &MitsubishiHeatPump::config_traits() { return traits_; }
+
+void MitsubishiHeatPump::update_swing_horizontal(const std::string &swing) {
+  this->horizontal_swing_state_ = swing;
+
+  if (this->horizontal_vane_select_ != nullptr &&
+      this->horizontal_vane_select_->state != this->horizontal_swing_state_) {
+    this->horizontal_vane_select_->publish_state(
+        this->horizontal_swing_state_);  // Set current horizontal swing
+                                         // position
+  }
+}
+
+void MitsubishiHeatPump::update_swing_vertical(const std::string &swing) {
+  this->vertical_swing_state_ = swing;
+
+  if (this->vertical_vane_select_ != nullptr &&
+      this->vertical_vane_select_->state != this->vertical_swing_state_)
+    this->vertical_vane_select_->publish_state(
+        this->vertical_swing_state_);  // Set current vertical swing position
+}
+
+void MitsubishiHeatPump::set_vertical_vane_select(
+    select::Select *vertical_vane_select) {
+  this->vertical_vane_select_ = vertical_vane_select;
+  this->vertical_vane_select_->add_on_state_callback(
+      [this](const std::string &value, size_t index) {
+        if (value == this->vertical_swing_state_) return;
+        this->on_vertical_swing_change(value);
+      });
+}
+
+void MitsubishiHeatPump::set_horizontal_vane_select(
+    select::Select *horizontal_vane_select) {
+  this->horizontal_vane_select_ = horizontal_vane_select;
+  this->horizontal_vane_select_->add_on_state_callback(
+      [this](const std::string &value, size_t index) {
+        if (value == this->horizontal_swing_state_) return;
+        this->on_horizontal_swing_change(value);
+      });
+}
+
+void MitsubishiHeatPump::on_vertical_swing_change(const std::string &swing) {
+  ESP_LOGD(TAG, "Setting vertical swing position");
+  bool updated = false;
+
+  if (swing == "swing") {
+    hp->setVaneSetting("SWING");
+    updated = true;
+  } else if (swing == "auto") {
+    hp->setVaneSetting("AUTO");
+    updated = true;
+  } else if (swing == "up") {
+    hp->setVaneSetting("1");
+    updated = true;
+  } else if (swing == "up_center") {
+    hp->setVaneSetting("2");
+    updated = true;
+  } else if (swing == "center") {
+    hp->setVaneSetting("3");
+    updated = true;
+  } else if (swing == "down_center") {
+    hp->setVaneSetting("4");
+    updated = true;
+  } else if (swing == "down") {
+    hp->setVaneSetting("5");
+    updated = true;
+  } else {
+    ESP_LOGW(TAG, "Invalid vertical vane position %s", swing);
+  }
+
+  ESP_LOGD(TAG, "Vertical vane - Was HeatPump updated? %s", YESNO(updated));
+
+  // and the heat pump:
+  hp->update();
+}
+
+void MitsubishiHeatPump::on_horizontal_swing_change(const std::string &swing) {
+  ESP_LOGD(TAG, "Setting horizontal swing position");
+  bool updated = false;
+
+  if (swing == "swing") {
+    hp->setWideVaneSetting("SWING");
+    updated = true;
+  } else if (swing == "auto") {
+    hp->setWideVaneSetting("<>");
+    updated = true;
+  } else if (swing == "left") {
+    hp->setWideVaneSetting("<<");
+    updated = true;
+  } else if (swing == "left_center") {
+    hp->setWideVaneSetting("<");
+    updated = true;
+  } else if (swing == "center") {
+    hp->setWideVaneSetting("|");
+    updated = true;
+  } else if (swing == "right_center") {
+    hp->setWideVaneSetting(">");
+    updated = true;
+  } else if (swing == "right") {
+    hp->setWideVaneSetting(">>");
+    updated = true;
+  } else {
+    ESP_LOGW(TAG, "Invalid horizontal vane position %s", swing);
+  }
+
+  ESP_LOGD(TAG, "Horizontal vane - Was HeatPump updated? %s", YESNO(updated));
+
+  // and the heat pump:
+  hp->update();
 }
 
 /**
@@ -98,387 +200,426 @@ climate::ClimateTraits& MitsubishiHeatPump::config_traits() {
  * Maps HomeAssistant/ESPHome modes to Mitsubishi modes.
  */
 void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
-    ESP_LOGV(TAG, "Control called.");
+  ESP_LOGV(TAG, "Control called.");
 
-    bool updated = false;
-    bool has_mode = call.get_mode().has_value();
-    bool has_temp = call.get_target_temperature().has_value();
-    if (has_mode){
-        this->mode = *call.get_mode();
-    }
-    switch (this->mode) {
-        case climate::CLIMATE_MODE_COOL:
-            hp->setModeSetting("COOL");
-            hp->setPowerSetting("ON");
+  bool updated = false;
+  bool has_mode = call.get_mode().has_value();
+  bool has_temp = call.get_target_temperature().has_value();
+  if (has_mode) {
+    this->mode = *call.get_mode();
+  }
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_COOL:
+      hp->setModeSetting("COOL");
+      hp->setPowerSetting("ON");
 
-            if (has_mode){
-                if (cool_setpoint.has_value() && !has_temp) {
-                    hp->setTemperature(cool_setpoint.value());
-                    this->target_temperature = cool_setpoint.value();
-                }
-                this->action = climate::CLIMATE_ACTION_IDLE;
-                updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_HEAT:
-            hp->setModeSetting("HEAT");
-            hp->setPowerSetting("ON");
-            if (has_mode){
-                if (heat_setpoint.has_value() && !has_temp) {
-                    hp->setTemperature(heat_setpoint.value());
-                    this->target_temperature = heat_setpoint.value();
-                }
-                this->action = climate::CLIMATE_ACTION_IDLE;
-                updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_DRY:
-            hp->setModeSetting("DRY");
-            hp->setPowerSetting("ON");
-            if (has_mode){
-                this->action = climate::CLIMATE_ACTION_DRYING;
-                updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_HEAT_COOL:
-            hp->setModeSetting("AUTO");
-            hp->setPowerSetting("ON");
-            if (has_mode){
-                if (auto_setpoint.has_value() && !has_temp) {
-                    hp->setTemperature(auto_setpoint.value());
-                    this->target_temperature = auto_setpoint.value();
-                }
-                this->action = climate::CLIMATE_ACTION_IDLE;
-            }
-            updated = true;
-            break;
-        case climate::CLIMATE_MODE_FAN_ONLY:
-            hp->setModeSetting("FAN");
-            hp->setPowerSetting("ON");
-            if (has_mode){
-                this->action = climate::CLIMATE_ACTION_FAN;
-                updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_OFF:
-        default:
-            if (has_mode){
-                hp->setPowerSetting("OFF");
-                this->action = climate::CLIMATE_ACTION_OFF;
-                updated = true;
-            }
-            break;
-    }
-
-    if (has_temp){
-        ESP_LOGV(
-            "control", "Sending target temp: %.1f",
-            *call.get_target_temperature()
-        );
-        hp->setTemperature(*call.get_target_temperature());
-        this->target_temperature = *call.get_target_temperature();
+      if (has_mode) {
+        if (cool_setpoint.has_value() && !has_temp) {
+          hp->setTemperature(cool_setpoint.value());
+          this->target_temperature = cool_setpoint.value();
+        }
+        this->action = climate::CLIMATE_ACTION_IDLE;
         updated = true;
-    }
-
-    //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
-    if (call.get_fan_mode().has_value()) {
-        ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
-        this->fan_mode = *call.get_fan_mode();
-        switch(*call.get_fan_mode()) {
-            case climate::CLIMATE_FAN_OFF:
-                hp->setPowerSetting("OFF");
-                updated = true;
-                break;
-            case climate::CLIMATE_FAN_DIFFUSE:
-                hp->setFanSpeed("QUIET");
-                updated = true;
-                break;
-            case climate::CLIMATE_FAN_LOW:
-                hp->setFanSpeed("1");
-                updated = true;
-                break;
-            case climate::CLIMATE_FAN_MEDIUM:
-                hp->setFanSpeed("2");
-                updated = true;
-                break;
-            case climate::CLIMATE_FAN_MIDDLE:
-                hp->setFanSpeed("3");
-                updated = true;
-                break;
-            case climate::CLIMATE_FAN_HIGH:
-                hp->setFanSpeed("4");
-                updated = true;
-                break;
-            case climate::CLIMATE_FAN_ON:
-            case climate::CLIMATE_FAN_AUTO:
-            default:
-                hp->setFanSpeed("AUTO");
-                updated = true;
-                break;
+      }
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      hp->setModeSetting("HEAT");
+      hp->setPowerSetting("ON");
+      if (has_mode) {
+        if (heat_setpoint.has_value() && !has_temp) {
+          hp->setTemperature(heat_setpoint.value());
+          this->target_temperature = heat_setpoint.value();
         }
-    }
-
-    //const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
-    if (call.get_swing_mode().has_value()) {
-        ESP_LOGV(TAG, "control - requested swing mode is %s",
-                *call.get_swing_mode());
-
-        this->swing_mode = *call.get_swing_mode();
-        switch(*call.get_swing_mode()) {
-            case climate::CLIMATE_SWING_OFF:
-                hp->setVaneSetting("AUTO");
-                updated = true;
-                break;
-            case climate::CLIMATE_SWING_VERTICAL:
-                hp->setVaneSetting("SWING");
-                updated = true;
-                break;
-            default:
-                ESP_LOGW(TAG, "control - received unsupported swing mode request.");
-
+        this->action = climate::CLIMATE_ACTION_IDLE;
+        updated = true;
+      }
+      break;
+    case climate::CLIMATE_MODE_DRY:
+      hp->setModeSetting("DRY");
+      hp->setPowerSetting("ON");
+      if (has_mode) {
+        this->action = climate::CLIMATE_ACTION_DRYING;
+        updated = true;
+      }
+      break;
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      hp->setModeSetting("AUTO");
+      hp->setPowerSetting("ON");
+      if (has_mode) {
+        if (auto_setpoint.has_value() && !has_temp) {
+          hp->setTemperature(auto_setpoint.value());
+          this->target_temperature = auto_setpoint.value();
         }
-    }
-    ESP_LOGD(TAG, "control - Was HeatPump updated? %s", YESNO(updated));
+        this->action = climate::CLIMATE_ACTION_IDLE;
+      }
+      updated = true;
+      break;
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      hp->setModeSetting("FAN");
+      hp->setPowerSetting("ON");
+      if (has_mode) {
+        this->action = climate::CLIMATE_ACTION_FAN;
+        updated = true;
+      }
+      break;
+    case climate::CLIMATE_MODE_OFF:
+    default:
+      if (has_mode) {
+        hp->setPowerSetting("OFF");
+        this->action = climate::CLIMATE_ACTION_OFF;
+        updated = true;
+      }
+      break;
+  }
 
-    // send the update back to esphome:
-    this->publish_state();
-    // and the heat pump:
-    hp->update();
+  if (has_temp) {
+    ESP_LOGV("control", "Sending target temp: %.1f",
+             *call.get_target_temperature());
+    hp->setTemperature(*call.get_target_temperature());
+    this->target_temperature = *call.get_target_temperature();
+    updated = true;
+  }
+
+  // const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
+  if (call.get_fan_mode().has_value()) {
+    ESP_LOGV("control", "Requested fan mode is %d", *call.get_fan_mode());
+    this->fan_mode = *call.get_fan_mode();
+    switch (*call.get_fan_mode()) {
+      case climate::CLIMATE_FAN_OFF:
+        hp->setPowerSetting("OFF");
+        updated = true;
+        break;
+      case climate::CLIMATE_FAN_DIFFUSE:
+        hp->setFanSpeed("QUIET");
+        updated = true;
+        break;
+      case climate::CLIMATE_FAN_LOW:
+        hp->setFanSpeed("1");
+        updated = true;
+        break;
+      case climate::CLIMATE_FAN_MEDIUM:
+        hp->setFanSpeed("2");
+        updated = true;
+        break;
+      case climate::CLIMATE_FAN_MIDDLE:
+        hp->setFanSpeed("3");
+        updated = true;
+        break;
+      case climate::CLIMATE_FAN_HIGH:
+        hp->setFanSpeed("4");
+        updated = true;
+        break;
+      case climate::CLIMATE_FAN_ON:
+      case climate::CLIMATE_FAN_AUTO:
+      default:
+        hp->setFanSpeed("AUTO");
+        updated = true;
+        break;
+    }
+  }
+
+  // const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5",
+  // "SWING"};
+  if (call.get_swing_mode().has_value()) {
+    ESP_LOGV(TAG, "control - requested swing mode is %d",
+             *call.get_swing_mode());
+
+    this->swing_mode = *call.get_swing_mode();
+    switch (*call.get_swing_mode()) {
+      case climate::CLIMATE_SWING_OFF:
+        hp->setVaneSetting("AUTO");
+        hp->setWideVaneSetting("|");
+        updated = true;
+        break;
+      case climate::CLIMATE_SWING_VERTICAL:
+        hp->setVaneSetting("SWING");
+        hp->setWideVaneSetting("|");
+        updated = true;
+        break;
+      case climate::CLIMATE_SWING_HORIZONTAL:
+        hp->setVaneSetting("3");
+        hp->setWideVaneSetting("SWING");
+        updated = true;
+        break;
+      case climate::CLIMATE_SWING_BOTH:
+        hp->setVaneSetting("SWING");
+        hp->setWideVaneSetting("SWING");
+        updated = true;
+        break;
+      default:
+        ESP_LOGW(TAG, "control - received unsupported swing mode request.");
+    }
+  }
+  ESP_LOGD(TAG, "control - Was HeatPump updated? %s", YESNO(updated));
+
+  // esphome::delay(5000);
+
+  this->publish_state();
+  ESP_LOGD(TAG, "State updated");
+  // and the heat pump:
+  // send the update back to esphome:
+  // esphome::delay(5000);
+
+  hp->update();
+  ESP_LOGD(TAG, "Pump updated");
 }
 
 void MitsubishiHeatPump::hpSettingsChanged() {
-    heatpumpSettings currentSettings = hp->getSettings();
+  heatpumpSettings currentSettings = hp->getSettings();
 
-    if (currentSettings.power == NULL) {
-        /*
-         * We should always get a valid pointer here once the HeatPump
-         * component fully initializes. If HeatPump hasn't read the settings
-         * from the unit yet (hp->connect() doesn't do this, sadly), we'll need
-         * to punt on the update. Likely not an issue when run in callback
-         * mode, but that isn't working right yet.
-         */
-        ESP_LOGW(TAG, "Waiting for HeatPump to read the settings the first time.");
-        esphome::delay(10);
-        return;
-    }
-
+  if (currentSettings.power == NULL) {
     /*
-     * ************ HANDLE POWER AND MODE CHANGES ***********
-     * https://github.com/geoffdavis/HeatPump/blob/stream/src/HeatPump.h#L125
-     * const char* POWER_MAP[2]       = {"OFF", "ON"};
-     * const char* MODE_MAP[5]        = {"HEAT", "DRY", "COOL", "FAN", "AUTO"};
+     * We should always get a valid pointer here once the HeatPump
+     * component fully initializes. If HeatPump hasn't read the settings
+     * from the unit yet (hp->connect() doesn't do this, sadly), we'll need
+     * to punt on the update. Likely not an issue when run in callback
+     * mode, but that isn't working right yet.
      */
-    if (strcmp(currentSettings.power, "ON") == 0) {
-        if (strcmp(currentSettings.mode, "HEAT") == 0) {
-            this->mode = climate::CLIMATE_MODE_HEAT;
-            if (heat_setpoint != currentSettings.temperature) {
-                heat_setpoint = currentSettings.temperature;
-                save(currentSettings.temperature, heat_storage);
-            }
-            this->action = climate::CLIMATE_ACTION_IDLE;
-        } else if (strcmp(currentSettings.mode, "DRY") == 0) {
-            this->mode = climate::CLIMATE_MODE_DRY;
-            this->action = climate::CLIMATE_ACTION_DRYING;
-        } else if (strcmp(currentSettings.mode, "COOL") == 0) {
-            this->mode = climate::CLIMATE_MODE_COOL;
-            if (cool_setpoint != currentSettings.temperature) {
-                cool_setpoint = currentSettings.temperature;
-                save(currentSettings.temperature, cool_storage);
-            }
-            this->action = climate::CLIMATE_ACTION_IDLE;
-        } else if (strcmp(currentSettings.mode, "FAN") == 0) {
-            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-            this->action = climate::CLIMATE_ACTION_FAN;
-        } else if (strcmp(currentSettings.mode, "AUTO") == 0) {
-            this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-            if (auto_setpoint != currentSettings.temperature) {
-                auto_setpoint = currentSettings.temperature;
-                save(currentSettings.temperature, auto_storage);
-            }
-            this->action = climate::CLIMATE_ACTION_IDLE;
-        } else {
-            ESP_LOGW(
-                    TAG,
-                    "Unknown climate mode value %s received from HeatPump",
-                    currentSettings.mode
-            );
-        }
+    ESP_LOGW(TAG, "Waiting for HeatPump to read the settings the first time.");
+    esphome::delay(10);
+    return;
+  }
+
+  /*
+   * ************ HANDLE POWER AND MODE CHANGES ***********
+   * https://github.com/geoffdavis/HeatPump/blob/stream/src/HeatPump.h#L125
+   * const char* POWER_MAP[2]       = {"OFF", "ON"};
+   * const char* MODE_MAP[5]        = {"HEAT", "DRY", "COOL", "FAN", "AUTO"};
+   */
+  if (strcmp(currentSettings.power, "ON") == 0) {
+    if (strcmp(currentSettings.mode, "HEAT") == 0) {
+      this->mode = climate::CLIMATE_MODE_HEAT;
+      if (heat_setpoint != currentSettings.temperature) {
+        heat_setpoint = currentSettings.temperature;
+        save(currentSettings.temperature, heat_storage);
+      }
+      this->action = climate::CLIMATE_ACTION_IDLE;
+    } else if (strcmp(currentSettings.mode, "DRY") == 0) {
+      this->mode = climate::CLIMATE_MODE_DRY;
+      this->action = climate::CLIMATE_ACTION_DRYING;
+    } else if (strcmp(currentSettings.mode, "COOL") == 0) {
+      this->mode = climate::CLIMATE_MODE_COOL;
+      if (cool_setpoint != currentSettings.temperature) {
+        cool_setpoint = currentSettings.temperature;
+        save(currentSettings.temperature, cool_storage);
+      }
+      this->action = climate::CLIMATE_ACTION_IDLE;
+    } else if (strcmp(currentSettings.mode, "FAN") == 0) {
+      this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+      this->action = climate::CLIMATE_ACTION_FAN;
+    } else if (strcmp(currentSettings.mode, "AUTO") == 0) {
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+      if (auto_setpoint != currentSettings.temperature) {
+        auto_setpoint = currentSettings.temperature;
+        save(currentSettings.temperature, auto_storage);
+      }
+      this->action = climate::CLIMATE_ACTION_IDLE;
     } else {
-        this->mode = climate::CLIMATE_MODE_OFF;
-        this->action = climate::CLIMATE_ACTION_OFF;
+      ESP_LOGW(TAG, "Unknown climate mode value %s received from HeatPump",
+               currentSettings.mode);
     }
+  } else {
+    this->mode = climate::CLIMATE_MODE_OFF;
+    this->action = climate::CLIMATE_ACTION_OFF;
+  }
 
-    ESP_LOGI(TAG, "Climate mode is: %i", this->mode);
+  ESP_LOGI(TAG, "Climate mode is: %i", this->mode);
 
-    /*
-     * ******* HANDLE FAN CHANGES ********
-     *
-     * const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
-     */
-    if (strcmp(currentSettings.fan, "QUIET") == 0) {
-        this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
-    } else if (strcmp(currentSettings.fan, "1") == 0) {
-            this->fan_mode = climate::CLIMATE_FAN_LOW;
-    } else if (strcmp(currentSettings.fan, "2") == 0) {
-            this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-    } else if (strcmp(currentSettings.fan, "3") == 0) {
-            this->fan_mode = climate::CLIMATE_FAN_MIDDLE;
-    } else if (strcmp(currentSettings.fan, "4") == 0) {
-            this->fan_mode = climate::CLIMATE_FAN_HIGH;
-    } else { //case "AUTO" or default:
-        this->fan_mode = climate::CLIMATE_FAN_AUTO;
-    }
-    ESP_LOGI(TAG, "Fan mode is: %i", this->fan_mode);
+  /*
+   * ******* HANDLE FAN CHANGES ********
+   *
+   * const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
+   */
+  if (strcmp(currentSettings.fan, "QUIET") == 0) {
+    this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
+  } else if (strcmp(currentSettings.fan, "1") == 0) {
+    this->fan_mode = climate::CLIMATE_FAN_LOW;
+  } else if (strcmp(currentSettings.fan, "2") == 0) {
+    this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+  } else if (strcmp(currentSettings.fan, "3") == 0) {
+    this->fan_mode = climate::CLIMATE_FAN_MIDDLE;
+  } else if (strcmp(currentSettings.fan, "4") == 0) {
+    this->fan_mode = climate::CLIMATE_FAN_HIGH;
+  } else {  // case "AUTO" or default:
+    this->fan_mode = climate::CLIMATE_FAN_AUTO;
+  }
+  ESP_LOGI(TAG, "Fan mode is: %i", this->fan_mode);
 
-    /* ******** HANDLE MITSUBISHI VANE CHANGES ********
-     * const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
-     */
-    if (strcmp(currentSettings.vane, "SWING") == 0) {
-        this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-    }
-    else {
-        this->swing_mode = climate::CLIMATE_SWING_OFF;
-    }
-    ESP_LOGI(TAG, "Swing mode is: %i", this->swing_mode);
+  /* ******** HANDLE MITSUBISHI VANE CHANGES ********
+   * const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5",
+   * "SWING"};
+   */
+  if (strcmp(currentSettings.vane, "SWING") == 0 &&
+      strcmp(currentSettings.wideVane, "SWING") == 0) {
+    this->swing_mode = climate::CLIMATE_SWING_BOTH;
+  } else if (strcmp(currentSettings.vane, "SWING") == 0) {
+    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+  } else if (strcmp(currentSettings.wideVane, "SWING") == 0) {
+    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+  } else {
+    this->swing_mode = climate::CLIMATE_SWING_OFF;
+  }
+  ESP_LOGI(TAG, "Swing mode is: %i", this->swing_mode);
 
+  if (strcmp(currentSettings.vane, "SWING") == 0) {
+    this->update_swing_vertical("swing");
+  } else if (strcmp(currentSettings.vane, "AUTO") == 0) {
+    this->update_swing_vertical("auto");
+  } else if (strcmp(currentSettings.vane, "1") == 0) {
+    this->update_swing_vertical("up");
+  } else if (strcmp(currentSettings.vane, "2") == 0) {
+    this->update_swing_vertical("up_center");
+  } else if (strcmp(currentSettings.vane, "3") == 0) {
+    this->update_swing_vertical("center");
+  } else if (strcmp(currentSettings.vane, "4") == 0) {
+    this->update_swing_vertical("down_center");
+  } else if (strcmp(currentSettings.vane, "5") == 0) {
+    this->update_swing_vertical("down");
+  }
 
+  ESP_LOGI(TAG, "Vertical vane mode is: %s", currentSettings.vane);
 
-    /*
-     * ******** HANDLE TARGET TEMPERATURE CHANGES ********
-     */
-    this->target_temperature = currentSettings.temperature;
-    ESP_LOGI(TAG, "Target temp is: %f", this->target_temperature);
+  if (strcmp(currentSettings.wideVane, "SWING") == 0) {
+    this->update_swing_horizontal("swing");
+  } else if (strcmp(currentSettings.wideVane, "<>") == 0) {
+    this->update_swing_horizontal("auto");
+  } else if (strcmp(currentSettings.wideVane, "<<") == 0) {
+    this->update_swing_horizontal("left");
+  } else if (strcmp(currentSettings.wideVane, "<") == 0) {
+    this->update_swing_horizontal("left_center");
+  } else if (strcmp(currentSettings.wideVane, "|") == 0) {
+    this->update_swing_horizontal("center");
+  } else if (strcmp(currentSettings.wideVane, ">") == 0) {
+    this->update_swing_horizontal("right_center");
+  } else if (strcmp(currentSettings.wideVane, ">>") == 0) {
+    this->update_swing_horizontal("right");
+  }
 
-    /*
-     * ******** Publish state back to ESPHome. ********
-     */
-    this->publish_state();
+  ESP_LOGI(TAG, "Horizontal vane mode is: %s", currentSettings.wideVane);
+
+  /*
+   * ******** HANDLE TARGET TEMPERATURE CHANGES ********
+   */
+  this->target_temperature = currentSettings.temperature;
+  ESP_LOGI(TAG, "Target temp is: %f", this->target_temperature);
+
+  /*
+   * ******** Publish state back to ESPHome. ********
+   */
+  this->publish_state();
 }
 
 /**
  * Report changes in the current temperature sensed by the HeatPump.
  */
 void MitsubishiHeatPump::hpStatusChanged(heatpumpStatus currentStatus) {
-    this->current_temperature = currentStatus.roomTemperature;
-    switch (this->mode) {
-        case climate::CLIMATE_MODE_HEAT:
-            if (currentStatus.operating) {
-                this->action = climate::CLIMATE_ACTION_HEATING;
-            }
-            else {
-                this->action = climate::CLIMATE_ACTION_IDLE;
-            }
-            break;
-        case climate::CLIMATE_MODE_COOL:
-            if (currentStatus.operating) {
-                this->action = climate::CLIMATE_ACTION_COOLING;
-            }
-            else {
-                this->action = climate::CLIMATE_ACTION_IDLE;
-            }
-            break;
-        case climate::CLIMATE_MODE_HEAT_COOL:
-            this->action = climate::CLIMATE_ACTION_IDLE;
-            if (currentStatus.operating) {
-              if (this->current_temperature > this->target_temperature) {
-                  this->action = climate::CLIMATE_ACTION_COOLING;
-              } else if (this->current_temperature < this->target_temperature) {
-                  this->action = climate::CLIMATE_ACTION_HEATING;
-              }
-            }
-            break;
-        case climate::CLIMATE_MODE_DRY:
-            if (currentStatus.operating) {
-                this->action = climate::CLIMATE_ACTION_DRYING;
-            }
-            else {
-                this->action = climate::CLIMATE_ACTION_IDLE;
-            }
-            break;
-        case climate::CLIMATE_MODE_FAN_ONLY:
-            this->action = climate::CLIMATE_ACTION_FAN;
-            break;
-        default:
-            this->action = climate::CLIMATE_ACTION_OFF;
-    }
+  this->current_temperature = currentStatus.roomTemperature;
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_HEAT:
+      if (currentStatus.operating) {
+        this->action = climate::CLIMATE_ACTION_HEATING;
+      } else {
+        this->action = climate::CLIMATE_ACTION_IDLE;
+      }
+      break;
+    case climate::CLIMATE_MODE_COOL:
+      if (currentStatus.operating) {
+        this->action = climate::CLIMATE_ACTION_COOLING;
+      } else {
+        this->action = climate::CLIMATE_ACTION_IDLE;
+      }
+      break;
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      this->action = climate::CLIMATE_ACTION_IDLE;
+      if (currentStatus.operating) {
+        if (this->current_temperature > this->target_temperature) {
+          this->action = climate::CLIMATE_ACTION_COOLING;
+        } else if (this->current_temperature < this->target_temperature) {
+          this->action = climate::CLIMATE_ACTION_HEATING;
+        }
+      }
+      break;
+    case climate::CLIMATE_MODE_DRY:
+      if (currentStatus.operating) {
+        this->action = climate::CLIMATE_ACTION_DRYING;
+      } else {
+        this->action = climate::CLIMATE_ACTION_IDLE;
+      }
+      break;
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      this->action = climate::CLIMATE_ACTION_FAN;
+      break;
+    default:
+      this->action = climate::CLIMATE_ACTION_OFF;
+  }
 
-    this->publish_state();
+  this->publish_state();
 }
 
 void MitsubishiHeatPump::set_remote_temperature(float temp) {
-    ESP_LOGD(TAG, "Setting remote temp: %.1f", temp);
-    this->hp->setRemoteTemperature(temp);
+  ESP_LOGD(TAG, "Setting remote temp: %.1f", temp);
+  this->hp->setRemoteTemperature(temp);
 }
 
 void MitsubishiHeatPump::setup() {
-    // This will be called by App.setup()
-    this->banner();
-    ESP_LOGCONFIG(TAG, "Setting up UART...");
-    if (!this->get_hw_serial_()) {
-        ESP_LOGCONFIG(
-                TAG,
-                "No HardwareSerial was provided. "
-                "Software serial ports are unsupported by this component."
-        );
-        this->mark_failed();
-        return;
-    }
-    this->check_logger_conflict_();
+  // This will be called by App.setup()
+  this->banner();
+  ESP_LOGCONFIG(TAG, "Setting up UART...");
+  if (!this->get_hw_serial_()) {
+    ESP_LOGCONFIG(TAG,
+                  "No HardwareSerial was provided. "
+                  "Software serial ports are unsupported by this component.");
+    this->mark_failed();
+    return;
+  }
+  this->check_logger_conflict_();
 
-    ESP_LOGCONFIG(TAG, "Intializing new HeatPump object.");
-    this->hp = new HeatPump();
-    this->current_temperature = NAN;
-    this->target_temperature = NAN;
-    this->fan_mode = climate::CLIMATE_FAN_OFF;
-    this->swing_mode = climate::CLIMATE_SWING_OFF;
+  ESP_LOGCONFIG(TAG, "Intializing new HeatPump object.");
+  this->hp = new HeatPump();
+  hp->enableExternalUpdate();
+  this->current_temperature = NAN;
+  this->target_temperature = NAN;
+  this->fan_mode = climate::CLIMATE_FAN_OFF;
+  this->swing_mode = climate::CLIMATE_SWING_OFF;
+  this->vertical_swing_state_ = "auto";
+  this->horizontal_swing_state_ = "auto";
 
 #ifdef USE_CALLBACKS
-    hp->setSettingsChangedCallback(
-            [this]() {
-                this->hpSettingsChanged();
-            }
-    );
+  hp->setSettingsChangedCallback([this]() { this->hpSettingsChanged(); });
 
-    hp->setStatusChangedCallback(
-            [this](heatpumpStatus currentStatus) {
-                this->hpStatusChanged(currentStatus);
-            }
-    );
+  hp->setStatusChangedCallback([this](heatpumpStatus currentStatus) {
+    this->hpStatusChanged(currentStatus);
+  });
 #endif
 
-    ESP_LOGCONFIG(
-            TAG,
-            "hw_serial(%p) is &Serial(%p)? %s",
-            this->get_hw_serial_(),
-            &Serial,
-            YESNO(this->get_hw_serial_() == &Serial)
-    );
+  ESP_LOGCONFIG(TAG, "hw_serial(%p) is &Serial(%p)? %s", this->get_hw_serial_(),
+                &Serial, YESNO(this->get_hw_serial_() == &Serial));
 
-    ESP_LOGCONFIG(TAG, "Calling hp->connect(%p)", this->get_hw_serial_());
+  ESP_LOGCONFIG(TAG, "Calling hp->connect(%p)", this->get_hw_serial_());
 
-    if (hp->connect(this->get_hw_serial_(), this->baud_, -1, -1)) {
-        hp->sync();
-    }
-    else {
-        ESP_LOGCONFIG(
-                TAG,
-                "Connection to HeatPump failed."
-                " Marking MitsubishiHeatPump component as failed."
-        );
-        this->mark_failed();
-    }
+  if (hp->connect(this->get_hw_serial_(), this->baud_, -1, -1)) {
+    hp->sync();
+  } else {
+    ESP_LOGCONFIG(TAG,
+                  "Connection to HeatPump failed."
+                  " Marking MitsubishiHeatPump component as failed.");
+    this->mark_failed();
+  }
 
-    // create various setpoint persistence:
-    cool_storage = global_preferences->make_preference<uint8_t>(this->get_object_id_hash() + 1);
-    heat_storage = global_preferences->make_preference<uint8_t>(this->get_object_id_hash() + 2);
-    auto_storage = global_preferences->make_preference<uint8_t>(this->get_object_id_hash() + 3);
+  // create various setpoint persistence:
+  cool_storage = global_preferences->make_preference<uint8_t>(
+      this->get_object_id_hash() + 1);
+  heat_storage = global_preferences->make_preference<uint8_t>(
+      this->get_object_id_hash() + 2);
+  auto_storage = global_preferences->make_preference<uint8_t>(
+      this->get_object_id_hash() + 3);
 
-    // load values from storage:
-    cool_setpoint = load(cool_storage);
-    heat_setpoint = load(heat_storage);
-    auto_setpoint = load(auto_storage);
+  // load values from storage:
+  cool_setpoint = load(cool_storage);
+  heat_setpoint = load(heat_storage);
+  auto_setpoint = load(auto_storage);
 
-    this->dump_config();
+  this->dump_config();
 }
 
 /**
@@ -486,30 +627,30 @@ void MitsubishiHeatPump::setup() {
  * of storing floats directly, we'll store the number of
  * TEMPERATURE_STEPs from MIN_TEMPERATURE.
  **/
-void MitsubishiHeatPump::save(float value, ESPPreferenceObject& storage) {
-    uint8_t steps = (value - ESPMHP_MIN_TEMPERATURE) / ESPMHP_TEMPERATURE_STEP;
-    storage.save(&steps);
+void MitsubishiHeatPump::save(float value, ESPPreferenceObject &storage) {
+  uint8_t steps = (value - ESPMHP_MIN_TEMPERATURE) / ESPMHP_TEMPERATURE_STEP;
+  storage.save(&steps);
 }
 
-optional<float> MitsubishiHeatPump::load(ESPPreferenceObject& storage) {
-    uint8_t steps = 0;
-    if (!storage.load(&steps)) {
-        return {};
-    }
-    return ESPMHP_MIN_TEMPERATURE + (steps * ESPMHP_TEMPERATURE_STEP);
+optional<float> MitsubishiHeatPump::load(ESPPreferenceObject &storage) {
+  uint8_t steps = 0;
+  if (!storage.load(&steps)) {
+    return {};
+  }
+  return ESPMHP_MIN_TEMPERATURE + (steps * ESPMHP_TEMPERATURE_STEP);
 }
 
 void MitsubishiHeatPump::dump_config() {
-    this->banner();
-    ESP_LOGI(TAG, "  Supports HEAT: %s", YESNO(true));
-    ESP_LOGI(TAG, "  Supports COOL: %s", YESNO(true));
-    ESP_LOGI(TAG, "  Supports AWAY mode: %s", YESNO(false));
-    ESP_LOGI(TAG, "  Saved heat: %.1f", heat_setpoint.value_or(-1));
-    ESP_LOGI(TAG, "  Saved cool: %.1f", cool_setpoint.value_or(-1));
-    ESP_LOGI(TAG, "  Saved auto: %.1f", auto_setpoint.value_or(-1));
+  this->banner();
+  ESP_LOGI(TAG, "  Supports HEAT: %s", YESNO(true));
+  ESP_LOGI(TAG, "  Supports COOL: %s", YESNO(true));
+  ESP_LOGI(TAG, "  Supports AWAY mode: %s", YESNO(false));
+  ESP_LOGI(TAG, "  Saved heat: %.1f", heat_setpoint.value_or(-1));
+  ESP_LOGI(TAG, "  Saved cool: %.1f", cool_setpoint.value_or(-1));
+  ESP_LOGI(TAG, "  Saved auto: %.1f", auto_setpoint.value_or(-1));
 }
 
 void MitsubishiHeatPump::dump_state() {
-    LOG_CLIMATE("", "MitsubishiHeatPump Climate", this);
-    ESP_LOGI(TAG, "HELLO");
+  LOG_CLIMATE("", "MitsubishiHeatPump Climate", this);
+  ESP_LOGI(TAG, "HELLO");
 }

--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -17,122 +17,133 @@
 
 #define USE_CALLBACKS
 
-#include "esphome.h"
-#include "esphome/core/preferences.h"
-
 #include "HeatPump.h"
+#include "esphome.h"
+#include "esphome/components/select/select.h"
+#include "esphome/core/preferences.h"
 using namespace esphome;
 
 #ifndef ESPMHP_H
 #define ESPMHP_H
 
-static const char* TAG = "MitsubishiHeatPump"; // Logging tag
+static const char *TAG = "MitsubishiHeatPump";  // Logging tag
 
-static const char* ESPMHP_VERSION = "2.4.1";
+static const char *ESPMHP_VERSION = "2.4.1";
 
 /* If polling interval is greater than 9 seconds, the HeatPump
 library reconnects, but doesn't then follow up with our data request.*/
-static const uint32_t ESPMHP_POLL_INTERVAL_DEFAULT = 500; // in milliseconds,
+static const uint32_t ESPMHP_POLL_INTERVAL_DEFAULT = 500;  // in milliseconds,
                                                            // 0 < X <= 9000
-static const uint8_t ESPMHP_MIN_TEMPERATURE = 16; // degrees C,
-                                                  // defined by hardware
-static const uint8_t ESPMHP_MAX_TEMPERATURE = 31; // degrees C,
-                                                  //defined by hardware
-static const float   ESPMHP_TEMPERATURE_STEP = 0.5; // temperature setting step,
-                                                    // in degrees C
+static const uint8_t ESPMHP_MIN_TEMPERATURE = 16;          // degrees C,
+                                                   // defined by hardware
+static const uint8_t ESPMHP_MAX_TEMPERATURE = 31;  // degrees C,
+                                                   // defined by hardware
+static const float ESPMHP_TEMPERATURE_STEP = 0.5;  // temperature setting step,
+                                                   // in degrees C
 
 class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
+ public:
+  /**
+   * Create a new MitsubishiHeatPump object
+   *
+   * Args:
+   *   hw_serial: pointer to an Arduino HardwareSerial instance
+   *   poll_interval: polling interval in milliseconds
+   */
+  MitsubishiHeatPump(HardwareSerial *hw_serial,
+                     uint32_t poll_interval = ESPMHP_POLL_INTERVAL_DEFAULT);
 
-    public:
+  // Print a banner with library information.
+  void banner() {
+    ESP_LOGI(TAG, "ESPHome MitsubishiHeatPump version %s", ESPMHP_VERSION);
+  }
 
-        /**
-         * Create a new MitsubishiHeatPump object
-         *
-         * Args:
-         *   hw_serial: pointer to an Arduino HardwareSerial instance
-         *   poll_interval: polling interval in milliseconds
-         */
-        MitsubishiHeatPump(
-            HardwareSerial* hw_serial,
-            uint32_t poll_interval=ESPMHP_POLL_INTERVAL_DEFAULT
-        );
+  // Set the baud rate. Must be called before setup() to have any effect.
+  void set_baud_rate(int);
 
-        // Print a banner with library information.
-        void banner() {
-            ESP_LOGI(TAG, "ESPHome MitsubishiHeatPump version %s",
-                    ESPMHP_VERSION);
-        }
+  // print the current configuration
+  void dump_config() override;
 
-        // Set the baud rate. Must be called before setup() to have any effect.
-        void set_baud_rate(int);
+  // handle a change in settings as detected by the HeatPump library.
+  void hpSettingsChanged();
 
-        // print the current configuration
-        void dump_config() override;
+  // Handle a change in status as detected by the HeatPump library.
+  void hpStatusChanged(heatpumpStatus currentStatus);
 
-        // handle a change in settings as detected by the HeatPump library.
-        void hpSettingsChanged();
+  // Set up the component, initializing the HeatPump object.
+  void setup() override;
 
-        // Handle a change in status as detected by the HeatPump library.
-        void hpStatusChanged(heatpumpStatus currentStatus);
+  // This is called every poll_interval.
+  void update() override;
 
-        // Set up the component, initializing the HeatPump object.
-        void setup() override;
+  // Configure the climate object with traits that we support.
+  climate::ClimateTraits traits() override;
 
-        // This is called every poll_interval.
-        void update() override;
+  // Get a mutable reference to the traits that we support.
+  climate::ClimateTraits &config_traits();
 
-        // Configure the climate object with traits that we support.
-        climate::ClimateTraits traits() override;
+  // Debugging function to print the object's state.
+  void dump_state();
 
-        // Get a mutable reference to the traits that we support.
-        climate::ClimateTraits& config_traits();
+  // Handle a request from the user to change settings.
+  void control(const climate::ClimateCall &call) override;
 
-        // Debugging function to print the object's state.
-        void dump_state();
+  // Use the temperature from an external sensor. Use
+  // set_remote_temp(0) to switch back to the internal sensor.
+  void set_remote_temperature(float);
 
-        // Handle a request from the user to change settings.
-        void control(const climate::ClimateCall &call) override;
+  void set_vertical_vane_select(select::Select *vertical_vane_select);
+  void set_horizontal_vane_select(select::Select *horizontal_vane_select);
 
-        // Use the temperature from an external sensor. Use
-        // set_remote_temp(0) to switch back to the internal sensor.
-        void set_remote_temperature(float);
+ protected:
+  // HeatPump object using the underlying Arduino library.
+  HeatPump *hp;
 
-    protected:
-        // HeatPump object using the underlying Arduino library.
-        HeatPump* hp;
+  // The ClimateTraits supported by this HeatPump.
+  climate::ClimateTraits traits_;
 
-        // The ClimateTraits supported by this HeatPump.
-        climate::ClimateTraits traits_;
+  // Vane position
+  void update_swing_horizontal(const std::string &swing);
+  void update_swing_vertical(const std::string &swing);
+  std::string vertical_swing_state_;
+  std::string horizontal_swing_state_;
 
-        // Allow the HeatPump class to use get_hw_serial_
-        friend class HeatPump;
+  // Allow the HeatPump class to use get_hw_serial_
+  friend class HeatPump;
 
-        //Accessor method for the HardwareSerial pointer
-        HardwareSerial* get_hw_serial_() {
-            return this->hw_serial_;
-        }
+  // Accessor method for the HardwareSerial pointer
+  HardwareSerial *get_hw_serial_() { return this->hw_serial_; }
 
-        //Print a warning message if we're using the sole hardware UART on an
-        //ESP8266 or UART0 on ESP32
-        void check_logger_conflict_();
+  // Print a warning message if we're using the sole hardware UART on an
+  // ESP8266 or UART0 on ESP32
+  void check_logger_conflict_();
 
-        // various prefs to save mode-specific temperatures, akin to how the IR
-        // remote works.
-        ESPPreferenceObject cool_storage;
-        ESPPreferenceObject heat_storage;
-        ESPPreferenceObject auto_storage;
+  // various prefs to save mode-specific temperatures, akin to how the IR
+  // remote works.
+  ESPPreferenceObject cool_storage;
+  ESPPreferenceObject heat_storage;
+  ESPPreferenceObject auto_storage;
 
-        optional<float> cool_setpoint;
-        optional<float> heat_setpoint;
-        optional<float> auto_setpoint;
+  optional<float> cool_setpoint;
+  optional<float> heat_setpoint;
+  optional<float> auto_setpoint;
 
-        static void save(float value, ESPPreferenceObject& storage);
-        static optional<float> load(ESPPreferenceObject& storage);
+  static void save(float value, ESPPreferenceObject &storage);
+  static optional<float> load(ESPPreferenceObject &storage);
 
-    private:
-        // Retrieve the HardwareSerial pointer from friend and subclasses.
-        HardwareSerial *hw_serial_;
-        int baud_ = 0;
+  select::Select *vertical_vane_select_ =
+      nullptr;  // Select to store manual position of vertical swing
+  select::Select *horizontal_vane_select_ =
+      nullptr;  // Select to store manual position of horizontal swing
+
+  // When received command to change the vane positions
+  void on_horizontal_swing_change(const std::string &swing);
+  void on_vertical_swing_change(const std::string &swing);
+
+ private:
+  // Retrieve the HardwareSerial pointer from friend and subclasses.
+  HardwareSerial *hw_serial_;
+  int baud_ = 0;
 };
 
 #endif

--- a/components/mitsubishi_heatpump/panasonic_ac_select.h
+++ b/components/mitsubishi_heatpump/panasonic_ac_select.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+
+class MitsubishiACSelect : public select::Select, public Component {
+ protected:
+  void control(const std::string &value) override {
+    this->publish_state(value);
+  }
+};
+
+}  // namespace esphome


### PR DESCRIPTION
- Add vertical and horizontal vane selects as done for Panasonic pumps; https://github.com/DomiStyle/esphome-panasonic-ac 
- Add `HORIZONTAL` and `BOTH` swing mode options in additon to `OFF` and `VERTICAL`
- Fix logging bug causing ESP to crash

Note: This PR is a bit rough around the edges - it has been almost 2 decades since I last worked with C/C++
- I've tried to reformat the code according to the Google style (as used by ESPHome), but actually not sure whether VSCode did it or applied another format (not familiar with C codestyles)
- VSCode also decided to reformat the README.md when I updated it.

Frankly I do not expect this PR to get merged especially due to the number of changed lines by the formatter, but I though maybe some users would like to try it out as it the features have been requested in several issues.