### PR TITLE
feat: Add callback to log raw packets

### DIFF
--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -444,6 +444,8 @@ void MitsubishiHeatPump::setup() {
                 this->hpStatusChanged(currentStatus);
             }
     );
+
+    hp->setPacketCallback(this->log_packet);    
 #endif
 
     ESP_LOGCONFIG(
@@ -512,4 +514,17 @@ void MitsubishiHeatPump::dump_config() {
 void MitsubishiHeatPump::dump_state() {
     LOG_CLIMATE("", "MitsubishiHeatPump Climate", this);
     ESP_LOGI(TAG, "HELLO");
+}
+
+void MitsubishiHeatPump::log_packet(byte* packet, unsigned int length, char* packetDirection) {
+    String packetHex;
+    char textBuf[15];
+
+    for (int i = 0; i < length; i++) {
+        memset(textBuf, 0, 15);
+        sprintf(textBuf, "%02X ", packet[i]);
+        packetHex += textBuf;
+    }
+    
+    ESP_LOGV(TAG, "PKT: [%s] %s", packetDirection, packetHex.c_str());
 }

--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -129,6 +129,8 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         static void save(float value, ESPPreferenceObject& storage);
         static optional<float> load(ESPPreferenceObject& storage);
 
+        static void log_packet(byte* packet, unsigned int length, char* packetDirection);
+
     private:
         // Retrieve the HardwareSerial pointer from friend and subclasses.
         HardwareSerial *hw_serial_;


### PR DESCRIPTION
Quick and dirty PR made by someone who doesn't really write C++, apologies in advance! I wrote this while trying to diagnose the problem in #71 and thought it might be useful to others.

This pull request aims to add a verbose log line for raw packet data going over the wire. This is useful for debugging and reverse engineering of the protocol and ensuring that serial communication to the heat pump actually is working.