### PR TITLE
Fix for crash when changing fan modes

### DIFF
--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -89,7 +89,6 @@ def to_code(config):
     yield climate.register_climate(var, config)
     cg.add_library(
         name="HeatPump",
-        repository="https://github.com/markalston/HeatPump",
-        version="cea90c5ed48d24a904835f8918bd88cbc84cb1be",
-        #version="d6a29134401d7caae1b8fca9c452c8eb92af60c5",
+        repository="https://github.com/SwiCago/HeatPump",
+        version="d6a29134401d7caae1b8fca9c452c8eb92af60c5",
     )

--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -90,5 +90,6 @@ def to_code(config):
     cg.add_library(
         name="HeatPump",
         repository="https://github.com/markalston/HeatPump",
+        version="cea90c5ed48d24a904835f8918bd88cbc84cb1be",
         #version="d6a29134401d7caae1b8fca9c452c8eb92af60c5",
     )

--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -90,5 +90,5 @@ def to_code(config):
     cg.add_library(
         name="HeatPump",
         repository="https://github.com/markalston/HeatPump",
-        version="d6a29134401d7caae1b8fca9c452c8eb92af60c5",
+        #version="d6a29134401d7caae1b8fca9c452c8eb92af60c5",
     )

--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -89,6 +89,6 @@ def to_code(config):
     yield climate.register_climate(var, config)
     cg.add_library(
         name="HeatPump",
-        repository="https://github.com/SwiCago/HeatPump",
+        repository="https://github.com/markalston/HeatPump",
         version="d6a29134401d7caae1b8fca9c452c8eb92af60c5",
     )

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -171,18 +171,17 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     }
 
     if (has_temp){
-        ESP_LOGV(
-            "control", "Sending target temp: %.1f",
+        ESP_LOGV(TAG, "control - Sending target temp: %.1f",
             *call.get_target_temperature()
         );
         hp->setTemperature(*call.get_target_temperature());
         this->target_temperature = *call.get_target_temperature();
         updated = true;
     }
-
+    ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (call.get_fan_mode().has_value()) {
-        ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
+        ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
         /*
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -440,7 +440,7 @@ void MitsubishiHeatPump::setup() {
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
     ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
-    delay(4000);
+    delay((int) 4000);
     ESP_LOGCONFIG(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGCONFIG(TAG, "Setting up UART...");

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -182,7 +182,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
 
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (call.get_fan_mode().has_value()) {
-        ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
+        ESP_LOGV("control", "Requested fan mode is %i", *call.get_fan_mode());
         this->fan_mode = *call.get_fan_mode();
         switch (*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -105,6 +105,14 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     bool has_temp = call.get_target_temperature().has_value();
 
     if (has_mode){
+        ESP_LOGV(TAG, "Has Mode");
+        return;
+        this->mode = *call.get_mode();
+    } else {
+        ESP_LOGV(TAG, "Doesn't Have Mode");
+        return;
+    }
+    if (has_mode){
         this->mode = *call.get_mode();
         switch (this->mode) {
             case climate::CLIMATE_MODE_COOL:

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -105,75 +105,61 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     bool has_temp = call.get_target_temperature().has_value();
 
     if (has_mode){
-        ESP_LOGV(TAG, "Has Mode");
-        return;
         this->mode = *call.get_mode();
-    } else {
-        ESP_LOGV(TAG, "Doesn't Have Mode");
-        return;
-    }
-    switch (this->mode) {
-        case climate::CLIMATE_MODE_COOL:
-            hp->setModeSetting("COOL");
-            hp->setPowerSetting("ON");
+        switch (this->mode) {
+            case climate::CLIMATE_MODE_COOL:
+                hp->setModeSetting("COOL");
+                hp->setPowerSetting("ON");
 
-            if (has_mode){
                 if (cool_setpoint.has_value() && !has_temp) {
                     hp->setTemperature(cool_setpoint.value());
                     this->target_temperature = cool_setpoint.value();
                 }
                 this->action = climate::CLIMATE_ACTION_IDLE;
                 updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_HEAT:
-            hp->setModeSetting("HEAT");
-            hp->setPowerSetting("ON");
-            if (has_mode){
+                break;
+            case climate::CLIMATE_MODE_HEAT:
+                hp->setModeSetting("HEAT");
+                hp->setPowerSetting("ON");
+
                 if (heat_setpoint.has_value() && !has_temp) {
                     hp->setTemperature(heat_setpoint.value());
                     this->target_temperature = heat_setpoint.value();
                 }
                 this->action = climate::CLIMATE_ACTION_IDLE;
-                updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_DRY:
-            hp->setModeSetting("DRY");
-            hp->setPowerSetting("ON");
-            if (has_mode){
+                updated = true;        
+                break;
+            case climate::CLIMATE_MODE_DRY:
+                hp->setModeSetting("DRY");
+                hp->setPowerSetting("ON");
+         
                 this->action = climate::CLIMATE_ACTION_DRYING;
-                updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_HEAT_COOL:
-            hp->setModeSetting("AUTO");
-            hp->setPowerSetting("ON");
-            if (has_mode){
+                updated = true;          
+                break;
+            case climate::CLIMATE_MODE_HEAT_COOL:
+                hp->setModeSetting("AUTO");
+                hp->setPowerSetting("ON");
+
                 if (auto_setpoint.has_value() && !has_temp) {
                     hp->setTemperature(auto_setpoint.value());
                     this->target_temperature = auto_setpoint.value();
                 }
                 this->action = climate::CLIMATE_ACTION_IDLE;
-            }
-            updated = true;
-            break;
-        case climate::CLIMATE_MODE_FAN_ONLY:
-            hp->setModeSetting("FAN");
-            hp->setPowerSetting("ON");
-            if (has_mode){
+                updated = true;
+                break;
+            case climate::CLIMATE_MODE_FAN_ONLY:
+                hp->setModeSetting("FAN");
+                hp->setPowerSetting("ON");
                 this->action = climate::CLIMATE_ACTION_FAN;
                 updated = true;
-            }
-            break;
-        case climate::CLIMATE_MODE_OFF:
-        default:
-            if (has_mode){
+                break;
+            case climate::CLIMATE_MODE_OFF:
+            default:
                 hp->setPowerSetting("OFF");
                 this->action = climate::CLIMATE_ACTION_OFF;
                 updated = true;
-            }
-            break;
+                break;
+        }
     }
 
     if (has_temp){
@@ -188,7 +174,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (call.get_fan_mode().has_value()) {
         ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
-        /*
+
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
@@ -222,7 +208,6 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
                 //updated = true;
                 break;
         }
-        */
     }
 
     //const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -99,13 +99,18 @@ climate::ClimateTraits& MitsubishiHeatPump::config_traits() {
  */
 void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     ESP_LOGV(TAG, "Control called.");
-    ESP_LOGV(TAG, "Returning.");
-    return;
+
     bool updated = false;
     bool has_mode = call.get_mode().has_value();
     bool has_temp = call.get_target_temperature().has_value();
+
     if (has_mode){
+        ESP_LOGV(TAG, "Has Mode");
+        return;
         this->mode = *call.get_mode();
+    } else {
+        ESP_LOGV(TAG, "Doesn't Have Mode");
+        return;
     }
     switch (this->mode) {
         case climate::CLIMATE_MODE_COOL:

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -204,7 +204,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         this->fan_mode = *call.get_fan_mode();
         ESP_LOGV(TAG,"Got fan mode");
         return;
-        switch (switch(*call.get_fan_mode()) {) {
+        switch (*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
                 //hp->setPowerSetting("OFF");
                 //updated = true;

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -204,7 +204,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         this->fan_mode = *call.get_fan_mode();
         ESP_LOGV(TAG,"Got fan mode");
         return;
-        switch(this->fan_mode) {
+        switch (this->fan_mode) {
             case climate::CLIMATE_FAN_OFF:
                 //hp->setPowerSetting("OFF");
                 //updated = true;

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -440,7 +440,7 @@ void MitsubishiHeatPump::setup() {
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
     ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
-    delay((int) 4000);
+    delay((int)4000);
     ESP_LOGCONFIG(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGCONFIG(TAG, "Setting up UART...");

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -198,7 +198,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
-        ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
+        //ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
         ESP_LOGV(TAG,"Inside fan control block");          
   
         this->fan_mode = *call.get_fan_mode();

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -200,9 +200,11 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     if (has_fan) {
         //ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
         ESP_LOGV(TAG,"Inside fan control block");          
-        return;
+  
         this->fan_mode = *call.get_fan_mode();
-        switch(*call.get_fan_mode()) {
+        ESP_LOGV(TAG,"Got fan mode");
+        return;
+        switch(this->fan_mode) {
             case climate::CLIMATE_FAN_OFF:
                 //hp->setPowerSetting("OFF");
                 //updated = true;

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -269,7 +269,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     // send the update back to esphome:
     this->publish_state();
     // and the heat pump:
-    // hp->update();
+    hp->update();
 }
 
 void MitsubishiHeatPump::hpSettingsChanged() {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -117,7 +117,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         ESP_LOGV(TAG, "Doesn't Have Temp");
     }
     if (has_fan){
-        ESP_LOV(TAG, "Has Fan");
+        ESP_LOGV(TAG, "Has Fan");
     } else {
         ESP_LOGV(TAG, "Doesn't Have Fan");
     }

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -204,7 +204,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         this->fan_mode = *call.get_fan_mode();
         ESP_LOGV(TAG,"Got fan mode");
         return;
-        switch (this->fan_mode) {
+        switch (switch(*call.get_fan_mode()) {) {
             case climate::CLIMATE_FAN_OFF:
                 //hp->setPowerSetting("OFF");
                 //updated = true;

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -103,90 +103,76 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     bool updated = false;
     bool has_mode = call.get_mode().has_value();
     bool has_temp = call.get_target_temperature().has_value();
-    bool has_fan = call.get_fan_mode().has_value();
-    bool has_swing = call.get_swing_mode().has_value();
-        
-    if (has_mode){
-        ESP_LOGV(TAG, "Has Mode");
-    } else {
-        ESP_LOGV(TAG, "Doesn't Have Mode");
-    }
-    if (has_temp){
-        ESP_LOGV(TAG, "Has Temp");
-    } else {
-        ESP_LOGV(TAG, "Doesn't Have Temp");
-    }
-    if (has_fan){
-        ESP_LOGV(TAG, "Has Fan");
-    } else {
-        ESP_LOGV(TAG, "Doesn't Have Fan");
-    }
-    if (has_swing){
-        ESP_LOGV(TAG, "Has Swing");
-    } else {
-        ESP_LOGV(TAG, "Doesn't Have Swing");
-    }
-
     if (has_mode){
         this->mode = *call.get_mode();
-        switch (this->mode) {
-            case climate::CLIMATE_MODE_COOL:
-                hp->setModeSetting("COOL");
-                hp->setPowerSetting("ON");
+    }
+    switch (this->mode) {
+        case climate::CLIMATE_MODE_COOL:
+            hp->setModeSetting("COOL");
+            hp->setPowerSetting("ON");
 
+            if (has_mode){
                 if (cool_setpoint.has_value() && !has_temp) {
                     hp->setTemperature(cool_setpoint.value());
                     this->target_temperature = cool_setpoint.value();
                 }
                 this->action = climate::CLIMATE_ACTION_IDLE;
                 updated = true;
-                break;
-            case climate::CLIMATE_MODE_HEAT:
-                hp->setModeSetting("HEAT");
-                hp->setPowerSetting("ON");
-
+            }
+            break;
+        case climate::CLIMATE_MODE_HEAT:
+            hp->setModeSetting("HEAT");
+            hp->setPowerSetting("ON");
+            if (has_mode){
                 if (heat_setpoint.has_value() && !has_temp) {
                     hp->setTemperature(heat_setpoint.value());
                     this->target_temperature = heat_setpoint.value();
                 }
                 this->action = climate::CLIMATE_ACTION_IDLE;
-                updated = true;        
-                break;
-            case climate::CLIMATE_MODE_DRY:
-                hp->setModeSetting("DRY");
-                hp->setPowerSetting("ON");
-         
+                updated = true;
+            }
+            break;
+        case climate::CLIMATE_MODE_DRY:
+            hp->setModeSetting("DRY");
+            hp->setPowerSetting("ON");
+            if (has_mode){
                 this->action = climate::CLIMATE_ACTION_DRYING;
-                updated = true;          
-                break;
-            case climate::CLIMATE_MODE_HEAT_COOL:
-                hp->setModeSetting("AUTO");
-                hp->setPowerSetting("ON");
-
+                updated = true;
+            }
+            break;
+        case climate::CLIMATE_MODE_HEAT_COOL:
+            hp->setModeSetting("AUTO");
+            hp->setPowerSetting("ON");
+            if (has_mode){
                 if (auto_setpoint.has_value() && !has_temp) {
                     hp->setTemperature(auto_setpoint.value());
                     this->target_temperature = auto_setpoint.value();
                 }
                 this->action = climate::CLIMATE_ACTION_IDLE;
-                updated = true;
-                break;
-            case climate::CLIMATE_MODE_FAN_ONLY:
-                hp->setModeSetting("FAN");
-                hp->setPowerSetting("ON");
+            }
+            updated = true;
+            break;
+        case climate::CLIMATE_MODE_FAN_ONLY:
+            hp->setModeSetting("FAN");
+            hp->setPowerSetting("ON");
+            if (has_mode){
                 this->action = climate::CLIMATE_ACTION_FAN;
                 updated = true;
-                break;
-            case climate::CLIMATE_MODE_OFF:
-            default:
+            }
+            break;
+        case climate::CLIMATE_MODE_OFF:
+        default:
+            if (has_mode){
                 hp->setPowerSetting("OFF");
                 this->action = climate::CLIMATE_ACTION_OFF;
                 updated = true;
-                break;
-        }
+            }
+            break;
     }
 
     if (has_temp){
-        ESP_LOGV(TAG, "control - Sending target temp: %.1f",
+        ESP_LOGV(
+            "control", "Sending target temp: %.1f",
             *call.get_target_temperature()
         );
         hp->setTemperature(*call.get_target_temperature());
@@ -194,50 +180,38 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         updated = true;
     }
 
-    ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
-    if (has_fan) {
-        //ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
-        ESP_LOGV(TAG,"Inside fan control block");          
-  
+    if (call.get_fan_mode().has_value()) {
+       // ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
         this->fan_mode = *call.get_fan_mode();
-        ESP_LOGV(TAG,"Got fan mode");
-
-        switch (*call.get_fan_mode()) {
+        switch(*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
-                ESP_LOGV(TAG,"Setting Fan Off");      
                 hp->setPowerSetting("OFF");
                 updated = true;
                 break;
             case climate::CLIMATE_FAN_DIFFUSE:
-                ESP_LOGV(TAG,"Setting Fan Diffuse");  
                 hp->setFanSpeed("QUIET");
                 updated = true;
                 break;
             case climate::CLIMATE_FAN_LOW:
-                ESP_LOGV(TAG,"Setting Fan Low");  
                 hp->setFanSpeed("1");
                 updated = true;
                 break;
             case climate::CLIMATE_FAN_MEDIUM:
-                ESP_LOGV(TAG,"Setting Fan Medium");  
                 hp->setFanSpeed("2");
                 updated = true;
                 break;
             case climate::CLIMATE_FAN_MIDDLE:
-                ESP_LOGV(TAG,"Setting Fan Middle");  
                 hp->setFanSpeed("3");
                 updated = true;
                 break;
             case climate::CLIMATE_FAN_HIGH:
-                ESP_LOGV(TAG,"Setting Fan High");  
                 hp->setFanSpeed("4");
                 updated = true;
                 break;
             case climate::CLIMATE_FAN_ON:
             case climate::CLIMATE_FAN_AUTO:
             default:
-                ESP_LOGV(TAG,"Setting Fan Auto");  
                 hp->setFanSpeed("AUTO");
                 updated = true;
                 break;
@@ -245,7 +219,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     }
 
     //const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
-    if (has_swing) {
+    if (call.get_swing_mode().has_value()) {
         ESP_LOGV(TAG, "control - requested swing mode is %s",
                 *call.get_swing_mode());
 
@@ -269,7 +243,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     // send the update back to esphome:
     this->publish_state();
     // and the heat pump:
-    // hp->update();
+    hp->update();
 }
 
 void MitsubishiHeatPump::hpSettingsChanged() {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -127,7 +127,6 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         ESP_LOGV(TAG, "Doesn't Have Swing");
     }
 
-/*
     if (has_mode){
         this->mode = *call.get_mode();
         switch (this->mode) {
@@ -194,7 +193,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         this->target_temperature = *call.get_target_temperature();
         updated = true;
     }
-*/
+
     ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
@@ -207,40 +206,40 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         switch (*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
                 ESP_LOGV(TAG,"Setting Fan Off");      
-                //hp->setPowerSetting("OFF");
-                //updated = true;
+                hp->setPowerSetting("OFF");
+                updated = true;
                 break;
             case climate::CLIMATE_FAN_DIFFUSE:
                 ESP_LOGV(TAG,"Setting Fan Diffuse");  
-                //hp->setFanSpeed("QUIET");
-                //updated = true;
+                hp->setFanSpeed("QUIET");
+                updated = true;
                 break;
             case climate::CLIMATE_FAN_LOW:
                 ESP_LOGV(TAG,"Setting Fan Low");  
-                //hp->setFanSpeed("1");
-                //updated = true;
+                hp->setFanSpeed("1");
+                updated = true;
                 break;
             case climate::CLIMATE_FAN_MEDIUM:
                 ESP_LOGV(TAG,"Setting Fan Medium");  
-                //hp->setFanSpeed("2");
-                //updated = true;
+                hp->setFanSpeed("2");
+                updated = true;
                 break;
             case climate::CLIMATE_FAN_MIDDLE:
                 ESP_LOGV(TAG,"Setting Fan Middle");  
-                //hp->setFanSpeed("3");
-                //updated = true;
+                hp->setFanSpeed("3");
+                updated = true;
                 break;
             case climate::CLIMATE_FAN_HIGH:
                 ESP_LOGV(TAG,"Setting Fan High");  
-                //hp->setFanSpeed("4");
-                //updated = true;
+                hp->setFanSpeed("4");
+                updated = true;
                 break;
             case climate::CLIMATE_FAN_ON:
             case climate::CLIMATE_FAN_AUTO:
             default:
                 ESP_LOGV(TAG,"Setting Fan Auto");  
-                //hp->setFanSpeed("AUTO");
-                //updated = true;
+                hp->setFanSpeed("AUTO");
+                updated = true;
                 break;
         }
     }

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -183,6 +183,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (call.get_fan_mode().has_value()) {
         ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
+        /*
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
@@ -216,6 +217,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
                 //updated = true;
                 break;
         }
+        */
     }
 
     //const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -182,9 +182,9 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
 
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (call.get_fan_mode().has_value()) {
-       // ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
+        ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());
         this->fan_mode = *call.get_fan_mode();
-        switch(*call.get_fan_mode()) {
+        switch (*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
                 hp->setPowerSetting("OFF");
                 updated = true;

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -437,10 +437,11 @@ void MitsubishiHeatPump::set_remote_temperature(float temp) {
 }
 
 void MitsubishiHeatPump::setup() {
+    int delay_time = 4000;      
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
     ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
-    delay((int)4000);
+    delay(delay_time);
     ESP_LOGCONFIG(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGCONFIG(TAG, "Setting up UART...");

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -440,7 +440,7 @@ void MitsubishiHeatPump::setup() {
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
     ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
-    esphome::delay(4);
+    esphome::delay(4000);
     ESP_LOGCONFIG(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGCONFIG(TAG, "Setting up UART...");

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -186,34 +186,34 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
-                hp->setPowerSetting("OFF");
-                updated = true;
+                //hp->setPowerSetting("OFF");
+                //updated = true;
                 break;
             case climate::CLIMATE_FAN_DIFFUSE:
-                hp->setFanSpeed("QUIET");
-                updated = true;
+                //hp->setFanSpeed("QUIET");
+                //updated = true;
                 break;
             case climate::CLIMATE_FAN_LOW:
-                hp->setFanSpeed("1");
-                updated = true;
+                //hp->setFanSpeed("1");
+                //updated = true;
                 break;
             case climate::CLIMATE_FAN_MEDIUM:
-                hp->setFanSpeed("2");
-                updated = true;
+                //hp->setFanSpeed("2");
+                //updated = true;
                 break;
             case climate::CLIMATE_FAN_MIDDLE:
-                hp->setFanSpeed("3");
-                updated = true;
+                //hp->setFanSpeed("3");
+                //updated = true;
                 break;
             case climate::CLIMATE_FAN_HIGH:
-                hp->setFanSpeed("4");
-                updated = true;
+                //hp->setFanSpeed("4");
+                //updated = true;
                 break;
             case climate::CLIMATE_FAN_ON:
             case climate::CLIMATE_FAN_AUTO:
             default:
-                hp->setFanSpeed("AUTO");
-                updated = true;
+                //hp->setFanSpeed("AUTO");
+                //updated = true;
                 break;
         }
     }

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -127,7 +127,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         ESP_LOGV(TAG, "Doesn't Have Swing");
     }
 
-    return;
+/*
     if (has_mode){
         this->mode = *call.get_mode();
         switch (this->mode) {
@@ -194,11 +194,12 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         this->target_temperature = *call.get_target_temperature();
         updated = true;
     }
+*/
     ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
         ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
-
+        return;
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -105,6 +105,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     bool has_temp = call.get_target_temperature().has_value();
     bool has_fan = call.get_fan_mode().has_value();
     bool has_swing = call.get_swing_mode().has_value();
+        
     if (has_mode){
         ESP_LOGV(TAG, "Has Mode");
     } else {
@@ -115,6 +116,17 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     } else {
         ESP_LOGV(TAG, "Doesn't Have Temp");
     }
+    if (has_fan){
+        ESP_LOGV(TAG, "Has Fan");
+    } else {
+        ESP_LOGV(TAG, "Doesn't Have Fan");
+    }
+    if (has_swing){
+        ESP_LOGV(TAG, "Has Swing");
+    } else {
+        ESP_LOGV(TAG, "Doesn't Have Swing");
+    }
+
     return;
     if (has_mode){
         this->mode = *call.get_mode();

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -196,6 +196,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     }
 */
     ESP_LOGV(TAG,"About to enter fan control block");
+    return;
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
         ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -99,7 +99,8 @@ climate::ClimateTraits& MitsubishiHeatPump::config_traits() {
  */
 void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     ESP_LOGV(TAG, "Control called.");
-
+    ESP_LOGV(TAG, "Returning.");
+    return;
     bool updated = false;
     bool has_mode = call.get_mode().has_value();
     bool has_temp = call.get_target_temperature().has_value();

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -198,7 +198,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
-        //ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
+        ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
         ESP_LOGV(TAG,"Inside fan control block");          
   
         this->fan_mode = *call.get_fan_mode();

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -199,7 +199,8 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     return;
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
-        ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
+        //ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
+        ESP_LOGV(TAG,"Inside fan control block");          
         return;
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -438,6 +438,10 @@ void MitsubishiHeatPump::set_remote_temperature(float temp) {
 
 void MitsubishiHeatPump::setup() {
     // This will be called by App.setup()
+    // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
+    ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
+    delay(4000);
+    ESP_LOGCONFIG(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGCONFIG(TAG, "Setting up UART...");
     if (!this->get_hw_serial_()) {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -117,7 +117,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         ESP_LOGV(TAG, "Doesn't Have Temp");
     }
     if (has_fan){
-        ESP_LOGV(TAG, "Has Fan");
+        ESP_LOV(TAG, "Has Fan");
     } else {
         ESP_LOGV(TAG, "Doesn't Have Fan");
     }
@@ -439,11 +439,11 @@ void MitsubishiHeatPump::set_remote_temperature(float temp) {
 void MitsubishiHeatPump::setup() { 
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
-    ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
+    ESP_LOGV(TAG, "Delaying setup for 4 seconds...");        
     esphome::delay(4000);
-    ESP_LOGCONFIG(TAG, "Ending delay...");        
+    ESP_LOGV(TAG, "Ending delay...");        
     this->banner();
-    ESP_LOGCONFIG(TAG, "Setting up UART...");
+    ESP_LOGV(TAG, "Setting up UART...");
     if (!this->get_hw_serial_()) {
         ESP_LOGCONFIG(
                 TAG,
@@ -455,7 +455,7 @@ void MitsubishiHeatPump::setup() {
     }
     this->check_logger_conflict_();
 
-    ESP_LOGCONFIG(TAG, "Intializing new HeatPump object.");
+    ESP_LOGV(TAG, "Intializing new HeatPump object.");
     this->hp = new HeatPump();
     this->current_temperature = NAN;
     this->target_temperature = NAN;
@@ -476,7 +476,7 @@ void MitsubishiHeatPump::setup() {
     );
 #endif
 
-    ESP_LOGCONFIG(
+    ESP_LOGV(
             TAG,
             "hw_serial(%p) is &Serial(%p)? %s",
             this->get_hw_serial_(),

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -103,15 +103,19 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     bool updated = false;
     bool has_mode = call.get_mode().has_value();
     bool has_temp = call.get_target_temperature().has_value();
-
+    bool has_fan = call.get_fan_mode().has_value();
+    bool has_swing = call.get_swing_mode().has_value();
     if (has_mode){
         ESP_LOGV(TAG, "Has Mode");
-        return;
-        this->mode = *call.get_mode();
     } else {
         ESP_LOGV(TAG, "Doesn't Have Mode");
-        return;
     }
+    if (has_temp){
+        ESP_LOGV(TAG, "Has Temp");
+    } else {
+        ESP_LOGV(TAG, "Doesn't Have Temp");
+    }
+    return;
     if (has_mode){
         this->mode = *call.get_mode();
         switch (this->mode) {
@@ -180,7 +184,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     }
     ESP_LOGV(TAG,"About to enter fan control block");
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
-    if (call.get_fan_mode().has_value()) {
+    if (has_fan) {
         ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());
 
         this->fan_mode = *call.get_fan_mode();
@@ -219,7 +223,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     }
 
     //const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
-    if (call.get_swing_mode().has_value()) {
+    if (has_swing) {
         ESP_LOGV(TAG, "control - requested swing mode is %s",
                 *call.get_swing_mode());
 

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -196,7 +196,6 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     }
 */
     ESP_LOGV(TAG,"About to enter fan control block");
-    return;
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (has_fan) {
         //ESP_LOGV(TAG, "control - Requested fan mode is %s", *call.get_fan_mode());

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -203,7 +203,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
   
         this->fan_mode = *call.get_fan_mode();
         ESP_LOGV(TAG,"Got fan mode");
-        return;
+//        return;
         switch (*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
                 //hp->setPowerSetting("OFF");

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -436,12 +436,11 @@ void MitsubishiHeatPump::set_remote_temperature(float temp) {
     this->hp->setRemoteTemperature(temp);
 }
 
-void MitsubishiHeatPump::setup() {
-    int delay_time = 4000;      
+void MitsubishiHeatPump::setup() { 
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
     ESP_LOGCONFIG(TAG, "Delaying setup for 4 seconds...");        
-    delay(delay_time);
+    esphome::delay(4);
     ESP_LOGCONFIG(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGCONFIG(TAG, "Setting up UART...");

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -203,35 +203,42 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
   
         this->fan_mode = *call.get_fan_mode();
         ESP_LOGV(TAG,"Got fan mode");
-//        return;
+
         switch (*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
+                ESP_LOGV(TAG,"Setting Fan Off");      
                 //hp->setPowerSetting("OFF");
                 //updated = true;
                 break;
             case climate::CLIMATE_FAN_DIFFUSE:
+                ESP_LOGV(TAG,"Setting Fan Diffuse");  
                 //hp->setFanSpeed("QUIET");
                 //updated = true;
                 break;
             case climate::CLIMATE_FAN_LOW:
+                ESP_LOGV(TAG,"Setting Fan Low");  
                 //hp->setFanSpeed("1");
                 //updated = true;
                 break;
             case climate::CLIMATE_FAN_MEDIUM:
+                ESP_LOGV(TAG,"Setting Fan Medium");  
                 //hp->setFanSpeed("2");
                 //updated = true;
                 break;
             case climate::CLIMATE_FAN_MIDDLE:
+                ESP_LOGV(TAG,"Setting Fan Middle");  
                 //hp->setFanSpeed("3");
                 //updated = true;
                 break;
             case climate::CLIMATE_FAN_HIGH:
+                ESP_LOGV(TAG,"Setting Fan High");  
                 //hp->setFanSpeed("4");
                 //updated = true;
                 break;
             case climate::CLIMATE_FAN_ON:
             case climate::CLIMATE_FAN_AUTO:
             default:
+                ESP_LOGV(TAG,"Setting Fan Auto");  
                 //hp->setFanSpeed("AUTO");
                 //updated = true;
                 break;

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -439,9 +439,9 @@ void MitsubishiHeatPump::set_remote_temperature(float temp) {
 void MitsubishiHeatPump::setup() { 
     // This will be called by App.setup()
     // FIXME Added delay due to ESP01s not connecting to heatpump when connected at same time as MHK2 to splitter.
-    ESP_LOGV(TAG, "Delaying setup for 4 seconds...");        
+    ESP_LOGI(TAG, "Delaying setup for 4 seconds...");        
     esphome::delay(4000);
-    ESP_LOGV(TAG, "Ending delay...");        
+    ESP_LOGI(TAG, "Ending delay...");        
     this->banner();
     ESP_LOGV(TAG, "Setting up UART...");
     if (!this->get_hw_serial_()) {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -243,7 +243,7 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
     // send the update back to esphome:
     this->publish_state();
     // and the heat pump:
-    hp->update();
+    // hp->update();
 }
 
 void MitsubishiHeatPump::hpSettingsChanged() {


### PR DESCRIPTION
The ESP device crashes completely and knocks out communication whenever you try to change fan modes.  With my fix the device is no longer crashing when changing fan modes.

The log line:

`ESP_LOGV("control", "Requested fan mode is %s", *call.get_fan_mode());`

crashes the device because fan mode returned is an integer not a string.

Also, the following line causes an error and needs a space:

`        switch(*call.get_fan_mode()) {`

This pull request fixes issues:

#83 
#59 