### PR TITLE
Fixes logging crash in fan mode and swing.

### DIFF
--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -219,7 +219,8 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
 
     //const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     if (call.get_fan_mode().has_value()) {
-        ESP_LOGV("control", "Requested fan mode is %d", *call.get_fan_mode());
+        ESP_LOGV("control", "Requested fan mode is %s",
+                 climate::climate_fan_mode_to_string(*call.get_fan_mode()));
         this->fan_mode = *call.get_fan_mode();
         switch(*call.get_fan_mode()) {
             case climate::CLIMATE_FAN_OFF:
@@ -255,10 +256,12 @@ void MitsubishiHeatPump::control(const climate::ClimateCall &call) {
         }
     }
 
+
+    ESP_LOGV(TAG, "in the swing mode stage");
     //const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
     if (call.get_swing_mode().has_value()) {
-        ESP_LOGD(TAG, "control - requested swing mode is %d",
-                *call.get_swing_mode());
+        ESP_LOGV(TAG, "control - requested swing mode is %s",
+                climate::climate_swing_mode_to_string(*call.get_swing_mode()));
 
         this->swing_mode = *call.get_swing_mode();
         switch(*call.get_swing_mode()) {


### PR DESCRIPTION
The logging for both fan mode and swing was trying to log unsigned integers as strings causing the esp device to crash. This change now logs the string representation of both the fan and swing modes at the verbose level.

There already exists #122 that addresses the crash in fan mode but it's lacking fixes for the swing mode and also is just logging the raw integer value which is meaningless for the user.