### PR TITLE
Mark component as failed if serial conflict is detected

### DIFF
--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -113,8 +113,8 @@ class MitsubishiHeatPump : public PollingComponent, public climate::Climate {
         }
 
         //Print a warning message if we're using the sole hardware UART on an
-        //ESP8266 or UART0 on ESP32
-        void check_logger_conflict_();
+        //ESP8266 or UART0 on ESP32, or if no serial was provided
+        bool verify_serial();
 
         // various prefs to save mode-specific temperatures, akin to how the IR
         // remote works.


### PR DESCRIPTION
This PR moves serial-related validations into a single method so that we can more reliably detect failure conditions related to the serial communication, and mark the component as failed early if so.

This prevents crashes when accessing `get_hw_serial_()` and lights up the web component even if UART0 is in conflict.