### PR TITLE
Add a feature to periodically republish the remote temperature 

### DIFF
--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -36,6 +36,7 @@ HORIZONTAL_SWING_OPTIONS = [
 VERTICAL_SWING_OPTIONS = ["swing", "auto", "up", "up_center", "center", "down_center", "down"]
 
 # Remote temperature timeout configuration
+CONF_REMOTE_PUBLISH_FREQUENCY = "remote_publish_frequency_seconds"
 CONF_REMOTE_OPERATING_TIMEOUT = "remote_temperature_operating_timeout_minutes"
 CONF_REMOTE_IDLE_TIMEOUT = "remote_temperature_idle_timeout_minutes"
 CONF_REMOTE_PING_TIMEOUT = "remote_temperature_ping_timeout_minutes"
@@ -68,6 +69,7 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.GenerateID(): cv.declare_id(MitsubishiHeatPump),
         cv.Optional(CONF_HARDWARE_UART, default="UART0"): valid_uart,
         cv.Optional(CONF_BAUD_RATE): cv.positive_int,
+        cv.Optional(CONF_REMOTE_PUBLISH_FREQUENCY): cv.positive_int,
         cv.Optional(CONF_REMOTE_OPERATING_TIMEOUT): cv.positive_int,
         cv.Optional(CONF_REMOTE_IDLE_TIMEOUT): cv.positive_int,
         cv.Optional(CONF_REMOTE_PING_TIMEOUT): cv.positive_int,
@@ -109,6 +111,9 @@ def to_code(config):
 
     if CONF_TX_PIN in config:
         cg.add(var.set_tx_pin(config[CONF_TX_PIN]))
+
+    if CONF_REMOTE_PUBLISH_FREQUENCY in config:
+        cg.add(var.set_remote_publish_frequency_seconds(config[CONF_REMOTE_PUBLISH_FREQUENCY]))
 
     if CONF_REMOTE_OPERATING_TIMEOUT in config:
         cg.add(var.set_remote_operating_timeout_minutes(config[CONF_REMOTE_OPERATING_TIMEOUT]))

--- a/components/mitsubishi_heatpump/espmhp.h
+++ b/components/mitsubishi_heatpump/espmhp.h
@@ -108,6 +108,12 @@ class MitsubishiHeatPump : public esphome::PollingComponent, public esphome::cli
         // and this heatpump.
         void ping();
 
+        // Number of seconds to tell the HP about the remote temperature (if set).
+        // Newer HP seem to forget the remote temperature much faster and therefore
+        // require the remote temp to set even if there isn't a change.  Anecdottaly,
+        // they seem to forget the temperature every 60s or so.
+        void set_remote_publish_frequency_seconds(int seconds);
+
         // Number of minutes before the heatpump reverts back to the internal
         // temperature sensor if the machine is currently operating.
         void set_remote_operating_timeout_minutes(int);
@@ -126,6 +132,9 @@ class MitsubishiHeatPump : public esphome::PollingComponent, public esphome::cli
 
         // The ClimateTraits supported by this HeatPump.
         esphome::climate::ClimateTraits traits_;
+
+        // Remote Temperature
+        float remote_temperature{0};
 
         // Vane position
         void update_swing_horizontal(const std::string &swing);
@@ -182,6 +191,8 @@ class MitsubishiHeatPump : public esphome::PollingComponent, public esphome::cli
         std::optional<std::chrono::duration<long long, std::ratio<60>>> remote_operating_timeout_;
         std::optional<std::chrono::duration<long long, std::ratio<60>>> remote_idle_timeout_;
         std::optional<std::chrono::duration<long long, std::ratio<60>>> remote_ping_timeout_;
+        std::optional<std::chrono::duration<long long, std::ratio<1>>>  remote_publish_frequency_;
+        std::optional<std::chrono::time_point<std::chrono::steady_clock>> last_remote_temperature_publish_;
         std::optional<std::chrono::time_point<std::chrono::steady_clock>> last_remote_temperature_sensor_update_;
         std::optional<std::chrono::time_point<std::chrono::steady_clock>> last_ping_request_;
 };


### PR DESCRIPTION
One of my Mitsubishi Heat Pumps does not hold the remote temperature after about 60s (my other, different model HPs do not have this problem).  I made this change to republish the remote temperature (off by default) in order to remind the HP of the remote temperature.